### PR TITLE
Fixing the undefined symbol problem under Linux (gcc)

### DIFF
--- a/cmake/modules/FindCycles.cmake
+++ b/cmake/modules/FindCycles.cmake
@@ -52,7 +52,7 @@ find_path(CYCLES_LIBRARY_DIR
 
     DOC "Cycles Libraries directory")
 
-set(CYCLES_LIBS cycles_bvh;cycles_device;cycles_graph;cycles_kernel;cycles_render;cycles_subd;cycles_util;extern_clew;extern_cuew;extern_numaapi)
+set(CYCLES_LIBS cycles_device;cycles_kernel;cycles_render;cycles_bvh;cycles_subd;cycles_graph;cycles_util;extern_clew;extern_cuew;extern_numaapi)
 
 foreach (lib ${CYCLES_LIBS})
     find_library(${lib}_LIBRARY


### PR DESCRIPTION
The order in which cycles libraries are now synced with the order cycles links them for the standalone application.
This avoids undefined symbols errors when a library is linked before parts of it are requested by later libraries.
This PR fixes #3 