### PR TITLE
Fix some build errors I hit in VS2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ string(TOUPPER ${boost_python_component} boost_python_component_upper)
 find_package(Boost COMPONENTS ${boost_python_component} thread program_options filesystem) # Not required
 
 if(NOT ${Boost_${boost_python_component_upper}_FOUND})
+  # We need to unset this or the new find_package won't overwrite it.
+  set (Boost_LIBRARIES )
   find_package(Boost COMPONENTS python thread program_options filesystem REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ find_package(Boost COMPONENTS ${boost_python_component} thread program_options f
 
 if(NOT ${Boost_${boost_python_component_upper}_FOUND})
   # We need to unset this or the new find_package won't overwrite it.
-  set (Boost_LIBRARIES )
+  unset(Boost_LIBRARIES)
   find_package(Boost COMPONENTS python thread program_options filesystem REQUIRED)
 endif()
 

--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -26,7 +26,21 @@
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /EHsc")
 
 # Standards compliant.
-set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings /Zc:inline")
+set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings")
+
+# The /Zc:inline option strips out the "arch_ctor_<name>" symbols used for
+# library initialization by ARCH_CONSTRUCTOR starting in Visual Studio 2019, 
+# causing release builds to fail. Disable the option for this and later 
+# versions.
+# 
+# For more details, see:
+# https://developercommunity.visualstudio.com/content/problem/914943/zcinline-removes-extern-symbols-inside-anonymous-n.html
+if (MSVC_VERSION GREATER_EQUAL 1920)
+    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline-")
+else()
+    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline")
+endif()
+ 
 
 # Turn on all but informational warnings.
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /W3")
@@ -108,3 +122,6 @@ set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Gm-")
 # with no symbols in it.  We do this a lot because of a pattern of having
 # a C++ source file for many header-only facilities, e.g. tf/bitUtils.cpp.
 set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /IGNORE:4221")
+
+# Prevents Python from defining this which is not needed since VS2015.
+_add_define("HAVE_SNPRINTF")


### PR DESCRIPTION
The first block is copied verbatim from Pixar's msvcdefaults.cmake