### PR TITLE
Enable depth aov output

### DIFF
--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -552,7 +552,7 @@ HdCyclesRenderDelegate::GetDefaultAovDescriptor(TfToken const& name) const
                                    : HdFormatUNorm8Vec4;
         return HdAovDescriptor(colorFormat, false, VtValue(GfVec4f(0.0f)));
     } else if (name == HdAovTokens->depth) {
-        return HdAovDescriptor(HdFormatFloat32, false, VtValue(1.0f));
+        return HdAovDescriptor(HdFormatFloat32, false, VtValue(0.f));
     } else if (name == HdAovTokens->primId || name == HdAovTokens->instanceId
                || name == HdAovTokens->elementId) {
         return HdAovDescriptor(HdFormatInt32, false, VtValue(-1));

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -448,6 +448,9 @@ HdCyclesRenderParam::_CyclesInitialize()
     m_bufferParams.full_width  = m_width;
     m_bufferParams.full_height = m_height;
 
+    ccl::Pass::add(ccl::PASS_DEPTH, m_bufferParams.passes, "depth");
+
+    m_cyclesScene->film->passes = m_bufferParams.passes;
     m_cyclesScene->film->exposure = config.exposure;
 
     if (config.enable_transparent_background)

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -118,7 +118,7 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
         if (numPixels != oldNumPixels) {
             m_colorBuffer.resize(numPixels * pixelSize);
             memset(m_colorBuffer.data(), 0, numPixels * pixelSize);
-            m_depthBuffer.resize(numPixels * pixelSize);
+            m_depthBuffer.resize(numPixels);
         }
     }
 

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -167,10 +167,10 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
                             }
                         }
                     }
-
-                    rb->Blit(HdFormatFloat32, w, h, 0, w,
-                             (const uint8_t*)m_depthBuffer.data());
                 }
+
+                rb->Blit(HdFormatFloat32, w, h, 0, w,
+                         (const uint8_t*)m_depthBuffer.data());
             }
         }
     }

--- a/plugin/hdCycles/renderPass.h
+++ b/plugin/hdCycles/renderPass.h
@@ -91,6 +91,7 @@ protected:
     GfMatrix4d m_viewMtx;
 
     std::vector<unsigned char> m_colorBuffer;
+    std::vector<float> m_depthBuffer;
 
 public:
     int m_width  = 0;


### PR DESCRIPTION
I'm not totally sure why storm's output is white.  I suspect it's because a different code path is traveled for render because it's renderBuffer is backed by GPU memory, but haven't verified this.  

They both output into depth aov with a single float component.

The results looks equivalent otherwise, and the output from cycles is what I would expect.

Storm depth:
![image](https://user-images.githubusercontent.com/6809385/90919171-cfdc2000-e39a-11ea-850f-d0f6f37742bd.png)
Cycles depth:
![image](https://user-images.githubusercontent.com/6809385/90919209-e4b8b380-e39a-11ea-9885-14611fd3d163.png)

