### PR TITLE
Uvs with interpolation = "vertex" don't render correctly

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -500,6 +500,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
 {
     HdCyclesRenderParam* param = (HdCyclesRenderParam*)renderParam;
     ccl::Scene* scene          = param->GetCyclesScene();
+    
 
     scene->mutex.lock();
 
@@ -766,19 +767,17 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                                  ++i) {
                                 uvIndices.push_back(i);
                             }
-                        }
+                            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
+                                uvs.data(), uvs.size(), HdTypeFloatVec2,
+                                &triangulated);
 
-                        meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
-                            uvs.data(), uvs.size(), HdTypeFloatVec2,
-                            &triangulated);
+                            VtVec2fArray triangulatedUvs
+                                = triangulated.Get<VtVec2fArray>();
 
-                        VtVec2fArray m_uvs_tri
-                            = triangulated.Get<VtVec2fArray>();
-                        if (m_useSubdivision && m_subdivEnabled) {
-                            _AddUVSet(pv.name, uvs, primvarDescsEntry.first);
-                        } else {
-                            _AddUVSet(pv.name, m_uvs_tri,
+                            _AddUVSet(pv.name, triangulatedUvs,
                                       primvarDescsEntry.first);
+                        } else {
+                            _AddUVSet(pv.name, uvs, primvarDescsEntry.first);
                         }
                     }
                 }

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -757,16 +757,9 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                     // TODO: Add more general uv support
                     //if (pv.role == HdPrimvarRoleTokens->textureCoordinate) {
                     if (value.IsHolding<VtArray<GfVec2f>>()) {
-                        VtVec2fArray uvs;
-                        VtIntArray uvIndices;
-                        uvs = value.UncheckedGet<VtArray<GfVec2f>>();
+                        VtVec2fArray uvs  = value.UncheckedGet<VtArray<GfVec2f>>();
                         if (primvarDescsEntry.first
                             == HdInterpolationFaceVarying) {
-                            uvIndices.reserve(m_faceVertexIndices.size());
-                            for (int i = 0; i < m_faceVertexIndices.size();
-                                 ++i) {
-                                uvIndices.push_back(i);
-                            }
                             meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
                                 uvs.data(), uvs.size(), HdTypeFloatVec2,
                                 &triangulated);


### PR DESCRIPTION
Face varying triangulation is run even for vertex varying uvs.

Images from a sample scene where the plane uses vertex varying uvs.  These are Maya default primitive shapes.

Before:
![image](https://user-images.githubusercontent.com/6809385/91220596-421d6f00-e6d1-11ea-9b88-e7f00c9b089a.png)

After:
![image](https://user-images.githubusercontent.com/6809385/91220384-f074e480-e6d0-11ea-812a-854fc6d4433f.png)

