### PR TITLE
Bugfix: Treat widths as diameter 

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -368,7 +368,8 @@ HdCyclesBasisCurves::_AddGenerated()
     ccl::float3 loc, size;
 
     // @TODO: The implementation of this function is broken
-    HdCyclesMeshTextureSpace(ccl::transform_inverse(m_cyclesObject->tfm), loc, size);
+    HdCyclesMeshTextureSpace(ccl::transform_inverse(m_cyclesObject->tfm), loc,
+                             size);
 
     if (m_cyclesMesh) {
         ccl::Attribute* attr_generated = m_cyclesMesh->attributes.add(
@@ -597,7 +598,7 @@ HdCyclesBasisCurves::_CreateCurves(ccl::Scene* a_scene)
         for (int j = 0; j < curveVertexCounts[i]; j++) {
             int idx = j + currentPointCount;
 
-            const float time = (float)j / (float)(curveVertexCounts[i]-1);
+            const float time = (float)j / (float)(curveVertexCounts[i] - 1);
 
             if (idx > m_points.size()) {
                 TF_WARN("Attempted to access invalid point. Continuing");
@@ -606,9 +607,10 @@ HdCyclesBasisCurves::_CreateCurves(ccl::Scene* a_scene)
 
             ccl::float3 usd_location = vec3f_to_float3(m_points[idx]);
 
+            // Hydra/USD treats widths as diameters so we halve before sending to cycles
             float radius = 0.1f;
             if (idx < m_widths.size())
-                radius = m_widths[idx];
+                radius = m_widths[idx] / 2.0f;
 
             m_cyclesHair->add_curve_key(usd_location, radius);
 
@@ -687,9 +689,10 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
 
         ccl::float3 ickey_loc = vec3f_to_float3(m_points[0]);
 
+        // Hydra/USD treats widths as diameters so we halve before sending to cycles
         float radius = 0.1f;
         if (m_widths.size() > 0)
-            radius = m_widths[0];
+            radius = m_widths[0] / 2.0f;
 
         v1 = vec3f_to_float3(m_points[1] - m_points[0]);
         if (isCameraOriented) {
@@ -725,10 +728,10 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
                 v1 = vec3f_to_float3(m_points[idx + 1] - m_points[idx - 1]);
             }
 
-
+            // Hydra/USD treats widths as diameters so we halve before sending to cycles
             float radius = 0.1f;
             if (idx < m_widths.size())
-                radius = m_widths[idx];
+                radius = m_widths[idx] / 2.0f;
 
             if (isCameraOriented) {
                 if (is_ortho)
@@ -858,9 +861,11 @@ HdCyclesBasisCurves::_CreateTubeMesh()
             }
 
             // Add vertex in circle
+
+            // Hydra/USD treats widths as diameters so we halve before sending to cycles
             float radius = 0.1f;
             if (idx < m_widths.size())
-                radius = m_widths[idx];
+                radius = m_widths[idx] / 2.0f;
 
             float angle = M_2PI_F / (float)m_curveResolution;
 


### PR DESCRIPTION
Cycles ingests radii for curves. Previously, our usd exporter from Blender would export the radius directly. However UsdGeomBasisCurves generally are stored as diameters. 

This change will also be made shortly in our opensource usd exporter.

(This commit also formats the file hence some additional changes)