### PR TITLE
Feature: OpenVDB Volumes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,13 +110,12 @@ find_package(OpenImageIO REQUIRED)
 
 find_package(OpenSubdiv)
 
-if(DEFINED ENV{REZ_OPENVDB_BASE})
-  message("REZ WITH OPENVDB")
+find_package(OpenVDB)
+if(${OpenVDB_FOUND})
   set(WITH_OPENVDB ON)
   set(OPENVDB_DEFINITIONS -DNOMINMAX -D_USE_MATH_DEFINES)
   add_definitions(-DWITH_OPENVDB ${OPENVDB_DEFINITIONS})
-  #add_definitions( -DWITH_OPENVDB=1 -DWITH_OPENVDB_BLOSC=1 )
-  find_package(OpenVDB)
+  message("[HDCYCLES] Configured with OpenVDB")
 endif()
 
 find_package(Embree)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,14 @@ find_package(OpenImageIO REQUIRED)
 
 find_package(OpenSubdiv)
 
-set(WITH_OPENVDB ON)
-set(OPENVDB_DEFINITIONS -DNOMINMAX -D_USE_MATH_DEFINES)
-add_definitions(-DWITH_OPENVDB ${OPENVDB_DEFINITIONS})
-find_package(OpenVDB)
+if(DEFINED ENV{REZ_OPENVDB_BASE})
+  message("REZ WITH OPENVDB")
+  set(WITH_OPENVDB ON)
+  set(OPENVDB_DEFINITIONS -DNOMINMAX -D_USE_MATH_DEFINES)
+  add_definitions(-DWITH_OPENVDB ${OPENVDB_DEFINITIONS})
+  #add_definitions( -DWITH_OPENVDB=1 -DWITH_OPENVDB_BLOSC=1 )
+  find_package(OpenVDB)
+endif()
 
 find_package(Embree)
 find_package(OpenColorIO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ find_package(TIFF REQUIRED)
 find_package(OpenImageIO REQUIRED)
 
 find_package(OpenSubdiv)
+
+set(WITH_OPENVDB ON)
+set(OPENVDB_DEFINITIONS -DNOMINMAX -D_USE_MATH_DEFINES)
+add_definitions(-DWITH_OPENVDB ${OPENVDB_DEFINITIONS})
 find_package(OpenVDB)
 
 find_package(Embree)

--- a/plugin/hdCycles/CMakeLists.txt
+++ b/plugin/hdCycles/CMakeLists.txt
@@ -55,7 +55,7 @@ pxr_plugin(${PXR_PACKAGE}
 
   INCLUDE_DIRS
     ${USD_INCLUDE_DIR}
-    ${Boost_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIR}
     ${TBB_INCLUDE_DIRS}
     ${Python_INCLUDE_DIRS}
     ${CYCLES_INCLUDE_DIRS}
@@ -76,6 +76,9 @@ pxr_plugin(${PXR_PACKAGE}
     material
     mesh
     points
+  
+    volume
+    openvdb_asset
 
     renderDelegate
     rendererPlugin

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -101,8 +101,10 @@ HdCyclesMaterial::HdCyclesMaterial(SdfPath const& id,
     , m_renderDelegate(a_renderDelegate)
 {
     m_shader        = new ccl::Shader();
+    m_shader->name  = id.GetString();
     m_shaderGraph   = new ccl::ShaderGraph();
     m_shader->graph = m_shaderGraph;
+
     if (m_renderDelegate)
         m_renderDelegate->GetCyclesRenderParam()->AddShader(m_shader);
 }
@@ -416,6 +418,11 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate,
         // Early out for already linked displacement graph
         if (graph->output()->input("Displacement")->link)
             return false;
+    } else if (terminal == HdCyclesMaterialTerminalTokens->volume) {
+        // Early out for already linked volume graph
+        if (graph->output()->input("Volume")->link) {
+            return false;
+        }
     }
 
     for (std::pair<TfToken, HdMaterialNetwork> net : networkMap.map) {
@@ -467,6 +474,12 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate,
                             graph->connect(cycles_node->output("Displacement"),
                                            graph->output()->input(
                                                "Displacement"));
+                        }
+                    }
+                    if (terminal == HdCyclesMaterialTerminalTokens->volume) {
+                        if (cycles_node->output("Volume") != NULL) {
+                            graph->connect(cycles_node->output("Volume"),
+                                           graph->output()->input("Volume"));
                         }
                     }
                 }
@@ -575,7 +588,6 @@ HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate,
     auto cyclesRenderParam     = static_cast<HdCyclesRenderParam*>(renderParam);
     HdCyclesRenderParam* param = (HdCyclesRenderParam*)renderParam;
 
-    param->GetCyclesScene()->mutex.lock();
 
     HdDirtyBits bits = *dirtyBits;
 
@@ -584,7 +596,6 @@ HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate,
 
         if (vtMat.IsHolding<HdMaterialNetworkMap>()) {
             if (m_shaderGraph) {
-                delete m_shaderGraph;
                 m_shaderGraph = new ccl::ShaderGraph();
             }
 
@@ -592,6 +603,7 @@ HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate,
 
             HdMaterialNetwork const* surface      = nullptr;
             HdMaterialNetwork const* displacement = nullptr;
+            HdMaterialNetwork const* volume       = nullptr;
 
             bool foundNetwork = false;
 
@@ -613,19 +625,29 @@ HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate,
                 }
             }
 
-            if (foundNetwork) {
-                m_shader->graph = m_shaderGraph;
+            if (GetMaterialNetwork(HdCyclesMaterialTerminalTokens->volume,
+                                   sceneDelegate, networkMap,
+                                   *cyclesRenderParam, &volume,
+                                   m_shaderGraph)) {
+                if (m_shader && m_shaderGraph) {
+                    material_updated = true;
+                }
+            }
 
-                m_shader->tag_update(param->GetCyclesScene());
-                m_shader->tag_used(param->GetCyclesScene());
-                param->Interrupt();
-            } else {
+            if (!material_updated) {
                 TF_CODING_WARNING("Material type not supported");
             }
         }
     }
 
-    param->GetCyclesScene()->mutex.unlock();
+    if (material_updated) {
+        if (m_shader->graph != m_shaderGraph)
+            m_shader->set_graph(m_shaderGraph);
+
+        m_shader->tag_update(param->GetCyclesScene());
+        m_shader->tag_used(param->GetCyclesScene());
+        param->Interrupt();
+    }
 
     *dirtyBits = Clean;
 }

--- a/plugin/hdCycles/openvdb_asset.cpp
+++ b/plugin/hdCycles/openvdb_asset.cpp
@@ -1,0 +1,67 @@
+//  Copyright 2020 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "openvdb_asset.h"
+
+#include <pxr/imaging/hd/renderIndex.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdCyclesOpenvdbAsset::HdCyclesOpenvdbAsset(HdCyclesRenderDelegate* a_delegate,
+                                           const SdfPath& id)
+    : HdField(id)
+{
+    TF_UNUSED(a_delegate);
+}
+
+void
+HdCyclesOpenvdbAsset::Sync(HdSceneDelegate* a_sceneDelegate,
+                           HdRenderParam* a_renderParam,
+                           HdDirtyBits* a_dirtyBits)
+{
+    TF_UNUSED(a_renderParam);
+    if (*a_dirtyBits & HdField::DirtyParams) {
+        auto& changeTracker
+            = a_sceneDelegate->GetRenderIndex().GetChangeTracker();
+        // But accessing this list happens on a single thread,
+        // as bprims are synced before rprims.
+        for (const auto& volume : _volumeList) {
+            changeTracker.MarkRprimDirty(volume,
+                                         HdChangeTracker::DirtyTopology);
+        }
+    }
+    *a_dirtyBits = HdField::Clean;
+}
+
+HdDirtyBits
+HdCyclesOpenvdbAsset::GetInitialDirtyBitsMask() const
+{
+    return HdField::AllDirty;
+}
+
+// This will be called from multiple threads.
+void
+HdCyclesOpenvdbAsset::TrackVolumePrimitive(const SdfPath& id)
+{
+    std::lock_guard<std::mutex> lock(_volumeListMutex);
+    _volumeList.insert(id);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -30,12 +30,14 @@
 #include <mutex>
 #include <unordered_set>
 
-#include <render/image_vdb.h>
-
-#  include <openvdb/openvdb.h>
+#ifdef WITH_OPENVDB
+#    include <render/image_vdb.h>
+#    include <openvdb/openvdb.h>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+#ifdef WITH_OPENVDB
 // Very temporary. Apparently Cycles has code to do this but it isnt in the head cycles standalone repo
 class HdCyclesVolumeLoader : public ccl::VDBImageLoader {
 public:
@@ -53,6 +55,7 @@ public:
         }
     }
 };
+#endif
 
 
 /// Utility class for translating Hydra Openvdb Asset to Arnold Volume.

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -1,0 +1,106 @@
+//  Copyright 2020 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef HD_CYCLES_OPENVDB_ASSET_H
+#define HD_CYCLES_OPENVDB_ASSET_H
+
+#include "api.h"
+#include <pxr/pxr.h>
+
+#include <pxr/imaging/hd/field.h>
+
+#include "renderDelegate.h"
+
+#include <mutex>
+#include <unordered_set>
+
+#include <render/image_vdb.h>
+
+#  include <openvdb/openvdb.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Very temporary. Apparently Cycles has code to do this but it isnt in the head cycles standalone repo
+class HdCyclesVolumeLoader : public ccl::VDBImageLoader {
+public:
+    HdCyclesVolumeLoader(const char* filepath, const char* grid_name)
+        : ccl::VDBImageLoader(grid_name)
+    {
+        openvdb::io::File file(filepath);
+
+        try {
+            file.setCopyMaxBytes(0);
+            file.open();
+            this->grid = file.readGrid(grid_name);
+        } catch (const openvdb::IoError& e) {
+            std::cout << "LOAD ERROR\n";
+        }
+    }
+};
+
+
+/// Utility class for translating Hydra Openvdb Asset to Arnold Volume.
+class HdCyclesOpenvdbAsset : public HdField {
+public:
+    /// Constructor for HdCyclesOpenvdbAsset
+    ///
+    /// @param delegate Pointer to the Render Delegate.
+    /// @param id Path to the OpenVDB Asset.
+    HDCYCLES_API
+    HdCyclesOpenvdbAsset(HdCyclesRenderDelegate* delegate, const SdfPath& id);
+
+    /// Syncing the Hydra Openvdb Asset to the Arnold Volume.
+    ///
+    /// The functions main purpose is to dirty every Volume primitive's
+    /// topology, so the grid definitions on the volume can be rebuilt, since
+    /// changing the the grid name on the openvdb asset doesn't dirty the
+    /// volume primitive, which holds the arnold volume shape.
+    ///
+    /// @param sceneDelegate Pointer to the Hydra Scene Delegate.
+    /// @param renderParam Pointer to a HdArnoldRenderParam instance.
+    /// @param dirtyBits Dirty Bits to sync.
+    HDCYCLES_API
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    /// Returns the initial Dirty Bits for the Primitive.
+    ///
+    /// @return Initial Dirty Bits.
+    HDCYCLES_API
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    /// Tracks a HdArnoldVolume primitive.
+    ///
+    /// Hydra separates the volume definitions from the grids each volume
+    /// requires, so we need to make sure each grid definition, which can be
+    /// shared between multiple volumes, knows which volume it belongs to.
+    ///
+    /// @param id Path to the Hydra Volume.
+    HDCYCLES_API
+    void TrackVolumePrimitive(const SdfPath& id);
+
+private:
+    std::mutex _volumeListMutex;  ///< Lock for the _volumeList.
+    /// Storing all the Hydra Volumes using this asset.
+    std::unordered_set<SdfPath, SdfPath::Hash> _volumeList;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // HD_CYCLES_OPENVDB_ASSET_H

--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -27,6 +27,9 @@
 #include "material.h"
 #include "mesh.h"
 #include "points.h"
+#include "volume.h"
+#include "openvdb_asset.h"
+
 #include "renderBuffer.h"
 #include "renderParam.h"
 #include "renderPass.h"
@@ -59,6 +62,7 @@ const TfTokenVector HdCyclesRenderDelegate::SUPPORTED_RPRIM_TYPES = {
     HdPrimTypeTokens->mesh,
     HdPrimTypeTokens->basisCurves,
     HdPrimTypeTokens->points,
+    HdPrimTypeTokens->volume,
 };
 
 const TfTokenVector HdCyclesRenderDelegate::SUPPORTED_SPRIM_TYPES = {
@@ -73,7 +77,8 @@ const TfTokenVector HdCyclesRenderDelegate::SUPPORTED_SPRIM_TYPES = {
 };
 
 const TfTokenVector HdCyclesRenderDelegate::SUPPORTED_BPRIM_TYPES = { 
-    HdPrimTypeTokens->renderBuffer
+    HdPrimTypeTokens->renderBuffer,
+    _tokens->openvdbAsset,
 };
 
 // clang-format on
@@ -420,6 +425,8 @@ HdCyclesRenderDelegate::CreateRprim(TfToken const& typeId,
         return new HdCyclesBasisCurves(rprimId, instancerId, this);
     } else if (typeId == HdPrimTypeTokens->points) {
         return new HdCyclesPoints(rprimId, instancerId, this);
+    } else if (typeId == HdPrimTypeTokens->volume) {
+        return new HdCyclesVolume(rprimId, instancerId, this);
     } else {
         TF_CODING_ERROR("Unknown Rprim type=%s id=%s", typeId.GetText(),
                         rprimId.GetText());
@@ -491,6 +498,9 @@ HdCyclesRenderDelegate::CreateBprim(TfToken const& typeId,
     if (typeId == HdPrimTypeTokens->renderBuffer) {
         return new HdCyclesRenderBuffer(bprimId);
     }
+    if (typeId == _tokens->openvdbAsset) {
+        return new HdCyclesOpenvdbAsset(this, bprimId);
+    }
     TF_CODING_ERROR("Unknown Bprim type=%s id=%s", typeId.GetText(),
                     bprimId.GetText());
     return nullptr;
@@ -502,7 +512,9 @@ HdCyclesRenderDelegate::CreateFallbackBprim(TfToken const& typeId)
     if (typeId == HdPrimTypeTokens->renderBuffer) {
         return new HdCyclesRenderBuffer(SdfPath());
     }
-
+    if (typeId == _tokens->openvdbAsset) {
+        return new HdCyclesOpenvdbAsset(this, SdfPath());
+    }
     TF_CODING_ERROR("Creating unknown fallback bprim type=%s",
                     typeId.GetText());
     return nullptr;

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -50,6 +50,14 @@ clamp(double d, double min, double max)
 
 HdCyclesRenderParam::HdCyclesRenderParam()
     : m_shouldUpdate(false)
+    , m_cyclesScene(nullptr)
+    , m_cyclesSession(nullptr)
+    , m_objectsUpdated(false)
+    , m_geometryUpdated(false)
+    , m_curveUpdated(false)
+    , m_meshUpdated(false)
+    , m_lightsUpdated(false)
+    , m_shadersUpdated(false)
 {
     _InitializeDefaults();
 }
@@ -138,13 +146,6 @@ void
 HdCyclesRenderParam::CommitResources()
 {
     if (m_shouldUpdate) {
-        if (m_cyclesScene->lights.size() > 0) {
-            if (!m_hasDomeLight)
-                SetBackgroundShader(nullptr, false);
-        } else {
-            SetBackgroundShader(nullptr, true);
-        }
-
         CyclesReset(false);
         m_shouldUpdate = false;
         ResumeRender();
@@ -529,6 +530,7 @@ HdCyclesRenderParam::CyclesReset(bool a_forceUpdate)
     if (m_objectsUpdated || m_shadersUpdated) {
         m_cyclesScene->object_manager->tag_update(m_cyclesScene);
         m_objectsUpdated = false;
+        m_shadersUpdated = false;
     }
     if (m_lightsUpdated) {
         m_cyclesScene->light_manager->tag_update(m_cyclesScene);
@@ -715,6 +717,13 @@ HdCyclesRenderParam::RemoveLight(ccl::Light* a_light)
         } else {
             ++it;
         }
+    }
+
+    if (m_cyclesScene->lights.size() > 0) {
+        if (!m_hasDomeLight)
+            SetBackgroundShader(nullptr, false);
+    } else {
+        SetBackgroundShader(nullptr, true);
     }
 
     if (m_lightsUpdated)

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -1,0 +1,319 @@
+//  Copyright 2020 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "volume.h"
+
+#include "openvdb_asset.h"
+
+#include "config.h"
+#include "material.h"
+#include "renderParam.h"
+#include "utils.h"
+
+#include <render/object.h>
+#include <render/scene.h>
+#include <render/shader.h>
+
+#include <render/image.h>
+#include <render/mesh.h>
+#include <render/object.h>
+
+#include <util/util_hash.h>
+#include <util/util_math_float3.h>
+
+#include <pxr/base/gf/vec2f.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec3i.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+
+#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/usd/sdf/path.h>
+
+#include <iostream>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (openvdbAsset)
+    (filePath)
+);
+// clang-format on
+
+HdCyclesVolume::HdCyclesVolume(SdfPath const& id, SdfPath const& instancerId,
+                               HdCyclesRenderDelegate* a_renderDelegate)
+    : HdVolume(id, instancerId)
+    , m_cyclesObject(nullptr)
+    , m_cyclesVolume(nullptr)
+    , m_renderDelegate(a_renderDelegate)
+{
+    static const HdCyclesConfig& config = HdCyclesConfig::GetInstance();
+    m_useMotionBlur                     = config.enable_motion_blur;
+
+    m_cyclesObject = _CreateObject();
+    m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
+
+    m_cyclesVolume = _CreateVolume();
+    m_renderDelegate->GetCyclesRenderParam()->AddMesh(m_cyclesVolume);
+
+    m_cyclesObject->geometry = m_cyclesVolume;
+}
+
+HdCyclesVolume::~HdCyclesVolume()
+{
+    if (m_cyclesObject) {
+        m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
+        delete m_cyclesObject;
+    }
+
+    if (m_cyclesVolume) {
+        m_renderDelegate->GetCyclesRenderParam()->RemoveMesh(m_cyclesVolume);
+        delete m_cyclesVolume;
+    }
+}
+
+void
+HdCyclesVolume::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits)
+{
+}
+
+HdDirtyBits
+HdCyclesVolume::_PropagateDirtyBits(HdDirtyBits bits) const
+{
+    return bits;
+}
+
+void
+HdCyclesVolume::Finalize(HdRenderParam* renderParam)
+{
+}
+
+ccl::Object*
+HdCyclesVolume::_CreateObject()
+{
+    // Create container object
+    ccl::Object* object = new ccl::Object();
+
+    object->visibility = ccl::PATH_RAY_ALL_VISIBILITY;
+
+    return object;
+}
+
+ccl::Mesh*
+HdCyclesVolume::_CreateVolume()
+{
+    // Create container object
+    ccl::Mesh* volume = new ccl::Mesh();
+
+    return volume;
+}
+
+void
+HdCyclesVolume::_PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate,
+                                ccl::Scene* scene)
+{
+    std::unordered_map<std::string, std::vector<TfToken>> openvdbs;
+    std::unordered_map<std::string, std::vector<TfToken>> houVdbs;
+
+    const auto fieldDescriptors = delegate->GetVolumeFieldDescriptors(id);
+    for (const auto& field : fieldDescriptors) {
+        auto* openvdbAsset = dynamic_cast<HdCyclesOpenvdbAsset*>(
+            delegate->GetRenderIndex().GetBprim(_tokens->openvdbAsset,
+                                                field.fieldId));
+
+        if (openvdbAsset == nullptr) {
+            continue;
+        }
+
+        openvdbAsset->TrackVolumePrimitive(id);
+
+        const auto vv = delegate->Get(field.fieldId, _tokens->filePath);
+
+        if (vv.IsHolding<SdfAssetPath>()) {
+            const auto& assetPath = vv.UncheckedGet<SdfAssetPath>();
+            auto path             = assetPath.GetResolvedPath();
+            if (path.empty()) {
+                path = assetPath.GetAssetPath();
+            }
+
+            /*if (TfStringStartsWith(path, "op:")) {
+                auto& fields = houVdbs[path];
+                if (std::find(fields.begin(), fields.end(), field.fieldName)
+                    == fields.end()) {
+                    fields.push_back(field.fieldName);
+                }
+                continue;
+            }*/
+            auto& fields = openvdbs[path];
+            if (std::find(fields.begin(), fields.end(), field.fieldName)
+                == fields.end()) {
+                fields.push_back(field.fieldName);
+
+                ccl::ustring name = ccl::ustring(field.fieldName.GetString());
+                ccl::ustring filepath = ccl::ustring(path);
+
+                ccl::AttributeStandard std = ccl::ATTR_STD_NONE;
+
+                if (name
+                    == ccl::Attribute::standard_name(
+                        ccl::ATTR_STD_VOLUME_DENSITY)) {
+                    std = ccl::ATTR_STD_VOLUME_DENSITY;
+                } else if (name
+                           == ccl::Attribute::standard_name(
+                               ccl::ATTR_STD_VOLUME_COLOR)) {
+                    std = ccl::ATTR_STD_VOLUME_COLOR;
+                } else if (name
+                           == ccl::Attribute::standard_name(
+                               ccl::ATTR_STD_VOLUME_FLAME)) {
+                    std = ccl::ATTR_STD_VOLUME_FLAME;
+                } else if (name
+                           == ccl::Attribute::standard_name(
+                               ccl::ATTR_STD_VOLUME_HEAT)) {
+                    std = ccl::ATTR_STD_VOLUME_HEAT;
+                } else if (name
+                           == ccl::Attribute::standard_name(
+                               ccl::ATTR_STD_VOLUME_TEMPERATURE)) {
+                    std = ccl::ATTR_STD_VOLUME_TEMPERATURE;
+                } else if (name
+                           == ccl::Attribute::standard_name(
+                               ccl::ATTR_STD_VOLUME_VELOCITY)) {
+                    std = ccl::ATTR_STD_VOLUME_VELOCITY;
+                }
+
+                if (std != ccl::ATTR_STD_NONE/*
+                     && m_cyclesVolume->need_attribute(scene, std))
+                    || m_cyclesVolume->need_attribute(scene, name)*/) {
+                    ccl::Attribute* attr
+                        = (std != ccl::ATTR_STD_NONE)
+                              ? m_cyclesVolume->attributes.add(std)
+                              : m_cyclesVolume->attributes.add(
+                                  name, ccl::TypeDesc::TypeFloat,
+                                  ccl::ATTR_ELEMENT_VOXEL);
+
+                    ccl::ImageLoader* loader
+                        = new HdCyclesVolumeLoader(filepath.c_str(),
+                                                   name.c_str());
+                    ccl::ImageParams params;
+
+                    attr->data_voxel() = scene->image_manager->add_image(loader,
+                                                                         params,
+                                                                         false);
+                }
+            }
+        }
+    }
+}
+
+void
+HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+                     HdDirtyBits* dirtyBits, TfToken const& reprSelector)
+{
+    SdfPath const& id = GetId();
+
+    HdCyclesRenderParam* param = (HdCyclesRenderParam*)renderParam;
+
+    ccl::Scene* scene = param->GetCyclesScene();
+
+    HdCyclesPDPIMap pdpi;
+    bool generate_new_curve = false;
+    bool update_volumes     = false;
+
+    if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
+        param->Interrupt();
+        _PopulateVolume(id, sceneDelegate, scene);
+        update_volumes = true;
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
+        update_volumes = true;
+        if (sceneDelegate->GetVisible(id)) {
+            m_cyclesObject->visibility |= ccl::PATH_RAY_ALL_VISIBILITY;
+        } else {
+            m_cyclesObject->visibility &= ~ccl::PATH_RAY_ALL_VISIBILITY;
+        }
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyTransform) {
+        m_transformSamples = HdCyclesSetTransform(m_cyclesObject, sceneDelegate,
+                                                  id, m_useMotionBlur);
+
+        update_volumes = true;
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
+        HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
+
+        for (auto& primvarDescsEntry : pdpi) {
+            for (auto& pv : primvarDescsEntry.second) {
+                if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
+                    VtValue value = GetPrimvar(sceneDelegate, pv.name);
+                    
+                }
+            }
+        }
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+        if (m_cyclesVolume) {
+            // Add default shader
+            const SdfPath& materialId = sceneDelegate->GetMaterialId(GetId());
+            const HdCyclesMaterial* material
+                = static_cast<const HdCyclesMaterial*>(
+                    sceneDelegate->GetRenderIndex().GetSprim(
+                        HdPrimTypeTokens->material, materialId));
+
+            if (material && material->GetCyclesShader()) {
+                m_cyclesVolume->used_shaders.push_back(
+                    material->GetCyclesShader());
+                material->GetCyclesShader()->tag_update(scene);
+            } else {
+                m_cyclesVolume->used_shaders.push_back(
+                    scene->default_volume);
+            }
+            update_volumes = true;
+        }
+    }
+
+    if (update_volumes) {
+        param->Interrupt();
+        m_cyclesVolume->used_shaders.push_back(
+                    scene->default_volume);
+        m_cyclesVolume->tag_update(scene, true);
+    }
+
+    *dirtyBits = HdChangeTracker::Clean;
+}
+
+HdDirtyBits
+HdCyclesVolume::GetInitialDirtyBitsMask() const
+{
+    return HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyPoints
+           | HdChangeTracker::DirtyNormals | HdChangeTracker::DirtyWidths
+           | HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyTransform
+           | HdChangeTracker::DirtyVisibility
+           | HdChangeTracker::DirtyMaterialId;
+}
+
+bool
+HdCyclesVolume::IsValid() const
+{
+    return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -22,6 +22,7 @@
 
 #include "api.h"
 
+#include "utils.h"
 #include "hdcycles.h"
 #include "renderDelegate.h"
 
@@ -31,8 +32,9 @@
 #include <pxr/imaging/hd/volume.h>
 #include <pxr/pxr.h>
 
-
+#ifdef WITH_OPENVDB
 #include <openvdb/openvdb.h>
+#endif
 
 namespace ccl {
 class Mesh;
@@ -144,6 +146,8 @@ private:
     HdCyclesRenderDelegate* m_renderDelegate;
 
     HdTimeSampleArray<GfMatrix4d, HD_CYCLES_MOTION_STEPS> m_transformSamples;
+
+    ccl::vector<ccl::Shader *> m_usedShaders;
 
     //openvdb::VolumeGridVector* grids;
 };

--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -1,0 +1,153 @@
+//  Copyright 2020 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef HD_CYCLES_VOLUME_H
+#define HD_CYCLES_VOLUME_H
+
+#include "api.h"
+
+#include "hdcycles.h"
+#include "renderDelegate.h"
+
+#include <util/util_transform.h>
+
+#include <pxr/base/gf/matrix4f.h>
+#include <pxr/imaging/hd/volume.h>
+#include <pxr/pxr.h>
+
+
+#include <openvdb/openvdb.h>
+
+namespace ccl {
+class Mesh;
+class Scene;
+class Object;
+class Geometry;
+}  // namespace ccl
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdSceneDelegate;
+class HdCyclesRenderDelegate;
+
+/**
+ * @brief Cycles Basis Curve Rprim mapped to Cycles Basis Curve
+ * 
+ */
+class HdCyclesVolume final : public HdVolume {
+public:
+    /**
+     * @brief Construct a new HdCycles Basis Curve object
+     * 
+     * @param id Path to the Basis Curve Primitive
+     * @param instancerId If specified the HdInstancer at this id uses this curve
+     * as a prototype
+     */
+    HdCyclesVolume(SdfPath const& id, SdfPath const& instancerId,
+                   HdCyclesRenderDelegate* a_renderDelegate);
+    /**
+     * @brief Destroy the HdCycles Basis Curves object
+     * 
+     */
+    virtual ~HdCyclesVolume();
+
+    /**
+     * @brief Pull invalidated material data and prepare/update the core Cycles 
+     * representation.
+     * 
+     * This must be thread safe.
+     * 
+     * @param sceneDelegate The data source for the basis curve
+     * @param renderParam State
+     * @param dirtyBits Which bits of scene data has changed
+     */
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits, TfToken const& reprSelector) override;
+
+    /**
+     * @brief Inform the scene graph which state needs to be downloaded in
+     * the first Sync() call
+     * 
+     * @return The initial dirty state this basis curve wants to query
+     */
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    /**
+     * @return Return true if this light is valid.
+     */
+    bool IsValid() const;
+
+    /**
+     * @brief Not Implemented
+     */
+    void Finalize(HdRenderParam* renderParam) override;
+
+protected:
+    /**
+     * @brief Initialize the given representation of this Rprim.
+     * This is called prior to syncing the prim.
+     * 
+     * @param reprToken The name of the repr to initialize
+     * @param dirtyBits In/Out dirty values
+     */
+    void _InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits) override;
+
+    /**
+     * @brief Set additional dirty bits
+     * 
+     * @param bits 
+     * @return New value of dirty bits
+     */
+    HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
+
+protected:
+    GfMatrix4f m_transform;
+
+    bool m_useMotionBlur;
+
+private:
+    /**
+     * @brief Create the cycles curve mesh and object representation
+     * 
+     * @return New allocated pointer to ccl::Mesh
+     */
+    ccl::Object* _CreateObject();
+
+    ccl::Mesh* _CreateVolume();
+
+    /**
+     * @brief Populate the Cycles mesh representation from delegate's data
+     */
+    void _PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate,
+                         ccl::Scene* scene);
+
+    ccl::Object* m_cyclesObject;
+
+    ccl::Mesh* m_cyclesVolume;
+
+    HdCyclesRenderDelegate* m_renderDelegate;
+
+    HdTimeSampleArray<GfMatrix4d, HD_CYCLES_MOTION_STEPS> m_transformSamples;
+
+    //openvdb::VolumeGridVector* grids;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // HD_CYCLES_VOLUME_H

--- a/plugin/ndrCycles/CMakeLists.txt
+++ b/plugin/ndrCycles/CMakeLists.txt
@@ -47,7 +47,7 @@ pxr_plugin(${PXR_PACKAGE}
 
   INCLUDE_DIRS
     ${USD_INCLUDE_DIR}
-    ${Boost_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIR}
     ${Python_INCLUDE_DIRS}
     ${CYCLES_INCLUDE_DIRS}
     ${OIIO_INCLUDE_DIRS}

--- a/plugin/ndrCycles/discovery.cpp
+++ b/plugin/ndrCycles/discovery.cpp
@@ -67,6 +67,9 @@ NdrCyclesDiscoveryPlugin::DiscoverNodes(const Context& context)
     temp_nodes.push_back("mix_closure");
     temp_nodes.push_back("add_closure");
     temp_nodes.push_back("hair_bsdf");
+    temp_nodes.push_back("principled_volume");
+    temp_nodes.push_back("scatter_volume");
+    temp_nodes.push_back("absorption_volume");
 
     for (const std::string& n : temp_nodes) {
         std::string cycles_id = std::string("cycles_" + n);


### PR DESCRIPTION
This allows Cycles to render OpenVDB USDVol volumes. Support for HdCycles volume materials is also included.

There is a known loading slowdown. This has yet been determined. It seems to be bottlenecked by Cycles internal texture loading functions. Blender Cycles internal does not experience this slowdown