### PR TITLE
Bugfix: Consolidate mesh texture space utils

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -360,17 +360,15 @@ HdCyclesBasisCurves::_AddUVS(TfToken name, VtValue value,
 }
 
 void
-HdCyclesBasisCurves::_AddGenerated()
+HdCyclesBasisCurves::_PopulateGenerated()
 {
     if (!m_cyclesObject)
         return;
 
     ccl::float3 loc, size;
 
-    // @TODO: The implementation of this function is broken
-    HdCyclesMeshTextureSpace(ccl::transform_inverse(m_cyclesObject->tfm), loc, size);
-
     if (m_cyclesMesh) {
+        HdCyclesMeshTextureSpace(m_cyclesMesh, loc, size);
         ccl::Attribute* attr_generated = m_cyclesMesh->attributes.add(
             ccl::ATTR_STD_GENERATED);
         ccl::float3* generated = attr_generated->data_float3();
@@ -378,6 +376,7 @@ HdCyclesBasisCurves::_AddGenerated()
         for (size_t i = 0; i < m_cyclesMesh->verts.size(); i++)
             generated[i] = m_cyclesMesh->verts[i] * size - loc;
     } else {
+        HdCyclesMeshTextureSpace(m_cyclesHair, loc, size);
         ccl::Attribute* attr_generated = m_cyclesHair->attributes.add(
             ccl::ATTR_STD_GENERATED);
         ccl::float3* generated = attr_generated->data_float3();
@@ -503,7 +502,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
 
             m_cyclesGeometry->compute_bounds();
 
-            _AddGenerated();
+            _PopulateGenerated();
 
             m_cyclesGeometry->tag_update(scene, true);
 

--- a/plugin/hdCycles/basisCurves.h
+++ b/plugin/hdCycles/basisCurves.h
@@ -144,10 +144,10 @@ protected:
     void _AddUVS(TfToken name, VtValue uvs, HdInterpolation interpolation);
 
     /**
-     * @brief Add generated coordinate for basisCurves
+     * @brief Populate generated coordinates for basisCurves
      * 
      */
-    void _AddGenerated();
+    void _PopulateGenerated();
 
 protected:
     VtVec3fArray m_points;

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -591,28 +591,11 @@ HdCyclesMesh::_PopulateCreases()
 }
 
 void
-HdCyclesMesh::_MeshTextureSpace(ccl::float3& loc, ccl::float3& size)
-{
-    // m_cyclesMesh->compute_bounds must be called before this
-    loc  = (m_cyclesMesh->bounds.max + m_cyclesMesh->bounds.min) / 2.0f;
-    size = (m_cyclesMesh->bounds.max - m_cyclesMesh->bounds.min) / 2.0f;
-
-    if (size.x != 0.0f)
-        size.x = 0.5f / size.x;
-    if (size.y != 0.0f)
-        size.y = 0.5f / size.y;
-    if (size.z != 0.0f)
-        size.z = 0.5f / size.z;
-
-    loc = loc * size - ccl::make_float3(0.5f, 0.5f, 0.5f);
-}
-
-void
 HdCyclesMesh::_PopulateGenerated(ccl::Scene* scene)
 {
     if (m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_GENERATED)) {
         ccl::float3 loc, size;
-        _MeshTextureSpace(loc, size);
+        HdCyclesMeshTextureSpace(m_cyclesMesh, loc, size);
 
         ccl::AttributeSet* attributes = (m_useSubdivision)
                                             ? &m_cyclesMesh->subd_attributes
@@ -633,7 +616,7 @@ HdCyclesMesh::_FinishMesh(ccl::Scene* scene)
     // This should no longer be necessary
     //_ComputeTangents(true);
 
-    // This must be done first, because _MeshTextureSpace requires computed min/max
+    // This must be done first, because HdCyclesMeshTextureSpace requires computed min/max
     m_cyclesMesh->compute_bounds();
 
     _PopulateGenerated(scene);

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -224,14 +224,6 @@ protected:
     void _PopulateCreases();
 
     /**
-     * @brief Cycles specific conversion required to get generated coord offsets
-     * 
-     * @param loc 
-     * @param size 
-     */
-    void _MeshTextureSpace(ccl::float3& loc, ccl::float3& size);
-
-    /**
      * @brief Populate generated coordinates attribute
      * 
      */

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -88,7 +88,7 @@ HdCyclesParseUDIMS(const ccl::string& a_filepath, ccl::vector<int>& a_tiles)
 }
 
 void
-HdCyclesMeshTextureSpace(ccl::Geometry& a_geom, ccl::float3& a_loc,
+HdCyclesMeshTextureSpace(ccl::Geometry* a_geom, ccl::float3& a_loc,
                          ccl::float3& a_size)
 {
     // m_cyclesMesh->compute_bounds must be called before this

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -92,17 +92,17 @@ HdCyclesMeshTextureSpace(ccl::Geometry& a_geom, ccl::float3& a_loc,
                          ccl::float3& a_size)
 {
     // m_cyclesMesh->compute_bounds must be called before this
-    loc  = (a_geom->bounds.max + a_geom->bounds.min) / 2.0f;
-    size = (a_geom->bounds.max - a_geom->bounds.min) / 2.0f;
+    a_loc  = (a_geom->bounds.max + a_geom->bounds.min) / 2.0f;
+    a_size = (a_geom->bounds.max - a_geom->bounds.min) / 2.0f;
 
-    if (size.x != 0.0f)
-        size.x = 0.5f / size.x;
-    if (size.y != 0.0f)
-        size.y = 0.5f / size.y;
-    if (size.z != 0.0f)
-        size.z = 0.5f / size.z;
+    if (a_size.x != 0.0f)
+        a_size.x = 0.5f / a_size.x;
+    if (a_size.y != 0.0f)
+        a_size.y = 0.5f / a_size.y;
+    if (a_size.z != 0.0f)
+        a_size.z = 0.5f / a_size.z;
 
-    loc = loc * size - ccl::make_float3(0.5f, 0.5f, 0.5f);
+    a_loc = a_loc * a_size - ccl::make_float3(0.5f, 0.5f, 0.5f);
 }
 
 /* ========== Material ========== */
@@ -589,7 +589,8 @@ mikk_compute_tangents(const char* layer_name, ccl::Mesh* mesh, bool need_sign,
         ccl::ustring name_sign;
 
         if (layer_name != NULL) {
-            name_sign = ccl::ustring((std::string(layer_name) + ".tangent_sign").c_str());
+            name_sign = ccl::ustring(
+                (std::string(layer_name) + ".tangent_sign").c_str());
         } else {
             name_sign = ccl::ustring("orco.tangent_sign");
         }

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -88,21 +88,21 @@ HdCyclesParseUDIMS(const ccl::string& a_filepath, ccl::vector<int>& a_tiles)
 }
 
 void
-HdCyclesMeshTextureSpace(ccl::Transform& a_transform, ccl::float3& a_loc,
+HdCyclesMeshTextureSpace(ccl::Geometry& a_geom, ccl::float3& a_loc,
                          ccl::float3& a_size)
 {
-    // @TODO: The implementation of this function is broken
-    a_loc  = ccl::make_float3(a_transform.x.w, a_transform.y.w, a_transform.z.w);
-    a_size = ccl::make_float3(a_transform.x.x, a_transform.y.y, a_transform.z.z);
+    // m_cyclesMesh->compute_bounds must be called before this
+    loc  = (a_geom->bounds.max + a_geom->bounds.min) / 2.0f;
+    size = (a_geom->bounds.max - a_geom->bounds.min) / 2.0f;
 
-    if (a_size.x != 0.0f)
-        a_size.x = 0.5f / a_size.x;
-    if (a_size.y != 0.0f)
-        a_size.y = 0.5f / a_size.y;
-    if (a_size.z != 0.0f)
-        a_size.z = 0.5f / a_size.z;
+    if (size.x != 0.0f)
+        size.x = 0.5f / size.x;
+    if (size.y != 0.0f)
+        size.y = 0.5f / size.y;
+    if (size.z != 0.0f)
+        size.z = 0.5f / size.z;
 
-    a_loc = a_loc * a_size - ccl::make_float3(0.5f, 0.5f, 0.5f);
+    loc = loc * size - ccl::make_float3(0.5f, 0.5f, 0.5f);
 }
 
 /* ========== Material ========== */

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -61,9 +61,17 @@ HDCYCLES_API
 void
 HdCyclesParseUDIMS(const ccl::string& a_filepath, ccl::vector<int>& a_tiles);
 
+/**
+ * @brief Cycles specific conversion required to get generated coord offsets
+ * 
+ * @param a_transform 
+ * @param a_loc 
+ * @param a_size 
+ * @return * Cycles 
+ */
 HDCYCLES_API
 void
-HdCyclesMeshTextureSpace(ccl::Transform& a_transform, ccl::float3& a_loc,
+HdCyclesMeshTextureSpace(ccl::Geometry* a_geom, ccl::float3& a_loc,
                          ccl::float3& a_size);
 
 /* ========== Material ========== */


### PR DESCRIPTION
A recent commit introduced a mesh specific coordinate space util, this was a duplicate of a common util already implemented. The logic has been consolidated and should allow basisCurves to also properly have generated coords