### PR TITLE
Refining how lights work in hdCycles

### DIFF
--- a/plugin/hdCycles/config.cpp
+++ b/plugin/hdCycles/config.cpp
@@ -87,6 +87,8 @@ TF_DEFINE_ENV_SETTING(HD_CYCLES_ENABLE_PROGRESS, false,
 TF_DEFINE_ENV_SETTING(HD_CYCLES_USE_TILED_RENDERING, false,
                       "Use Tiled Rendering (Experimental)");
 
+TF_DEFINE_ENV_SETTING(HD_CYCLES_UP_AXIS, "Z",
+                      "Set custom up axis (Z or Y currently supported)");
 
 // HdCycles Constructor
 HdCyclesConfig::HdCyclesConfig()
@@ -100,6 +102,8 @@ HdCyclesConfig::HdCyclesConfig()
     // -- HdCycles Settings
     enable_logging  = TfGetEnvSetting(HD_CYCLES_ENABLE_LOGGING);
     enable_progress = TfGetEnvSetting(HD_CYCLES_ENABLE_PROGRESS);
+
+    up_axis = TfGetEnvSetting(HD_CYCLES_UP_AXIS);
 
     enable_motion_blur = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_MOTION_BLUR",
                                                 false);

--- a/plugin/hdCycles/config.h
+++ b/plugin/hdCycles/config.h
@@ -104,6 +104,12 @@ public:
     bool enable_progress;
 
     /**
+     * @brief Set custom up axis (Z or Y currently supported)
+     *
+     */
+    std::string up_axis;
+
+    /**
      * @brief If enabled, HdCycles will populate object's motion and enable motion blur
      *
      */

--- a/plugin/hdCycles/light.h
+++ b/plugin/hdCycles/light.h
@@ -106,6 +106,18 @@ public:
     void Finalize(HdRenderParam* renderParam) override;
 
 private:
+    // Tracking for Cycles light shader graphs, saves on potentially 
+    // expensive new/delete re-creation of graphs for interactive sessions.
+    enum ShaderGraphBits : uint8_t {
+        Default     = 0,
+        Temperature = 1 << 0,
+        IES         = 1 << 1,
+        Texture     = 1 << 2,
+        All         = (Temperature
+                       |IES
+                       |Texture)
+    };
+
     /**
      * @brief Create the cycles light representation
      *
@@ -126,14 +138,22 @@ private:
      * @brief Get default shader graph for lights
      * 
      * @param isBackground Is the shader graph for the background shader
+     * @return Newly allocated default shader graph
      */
-    ccl::ShaderGraph *_GetDefaultShaderGraph(bool isBackground = false);
+    ccl::ShaderGraph *_GetDefaultShaderGraph(const bool isBackground = false);
+
+    /**
+     * @brief Find first shader node based on type.
+     * 
+     * @param graph ShaderGraph to search in
+     * @param type The type of ShaderNode to search for
+     * @return The first ShaderNode found based on type in graph
+     */
+    ccl::ShaderNode *_FindShaderNode(const ccl::ShaderGraph *graph, const ccl::NodeType *type);
 
     const TfToken m_hdLightType;
     ccl::Light* m_cyclesLight;
-
-    // Background light-specific
-    ccl::TextureCoordinateNode* m_backgroundTransform;
+    ShaderGraphBits m_shaderGraphBits;
 
     bool m_normalize;
 

--- a/plugin/hdCycles/light.h
+++ b/plugin/hdCycles/light.h
@@ -24,7 +24,9 @@
 
 #include "renderDelegate.h"
 
-#include <util/util_transform.h>
+#include <render/graph.h>
+#include <render/light.h>
+#include <render/nodes.h>
 
 #include <pxr/imaging/hd/light.h>
 #include <pxr/pxr.h>
@@ -120,21 +122,20 @@ private:
      */
     void _SetTransform(const ccl::Transform& a_transform);
 
+    /**
+     * @brief Get default shader graph for lights
+     * 
+     * @param isBackground Is the shader graph for the background shader
+     */
+    ccl::ShaderGraph *_GetDefaultShaderGraph(bool isBackground = false);
+
     const TfToken m_hdLightType;
     ccl::Light* m_cyclesLight;
-    ccl::Shader* m_cyclesShader;
-    ccl::EmissionNode* m_emissionNode;
 
-    // Background light specifics
-    ccl::BackgroundNode* m_backgroundNode;
+    // Background light-specific
     ccl::TextureCoordinateNode* m_backgroundTransform;
-    ccl::EnvironmentTextureNode* m_backgroundTexture;
-    ccl::BlackbodyNode* m_blackbodyNode;
-    std::string m_backgroundFilePath;
 
     bool m_normalize;
-    bool m_useTemperature;
-    float m_temperature;
 
     HdCyclesRenderDelegate* m_renderDelegate;
 

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -105,6 +105,13 @@ HdCyclesRenderParam::_InitializeDefaults()
     m_useSquareSamples                  = config.use_square_samples.value;
     m_useTiledRendering                 = config.use_tiled_rendering;
 
+    m_upAxis = UpAxis::Z;
+    if (config.up_axis == "Z") {
+        m_upAxis = UpAxis::Z;
+    } else if (config.up_axis == "Y") {
+        m_upAxis = UpAxis::Y;
+    }
+
 #ifdef WITH_CYCLES_LOGGING
     if (config.cycles_enable_logging) {
         ccl::util_logging_start();

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -155,6 +155,12 @@ protected:
     void _UpdateRenderTile(ccl::RenderTile& rtile, bool highlight);
 
 public:
+    // Up Axis. Z and Y currently supported.
+    enum UpAxis : uint8_t {
+        Z = 0,
+        Y = 1,
+    };
+
     /**
      * @brief Cycles general reset
      * 
@@ -385,6 +391,8 @@ private:
 
     bool m_useSquareSamples;
 
+    UpAxis m_upAxis;
+
 public:
     const bool& IsTiledRender() const { return m_useTiledRendering; }
 
@@ -411,6 +419,12 @@ public:
     ccl::Shader* default_vcol_surface;
 
     VtDictionary GetRenderStats() const;
+
+    /**
+     * @brief Get the up-axis that is set.
+     * 
+     */
+    UpAxis GetUpAxis() const { return m_upAxis; }
 
 private:
     ccl::Session* m_cyclesSession;


### PR DESCRIPTION
- Parameter changes on-sync will re-create a new shader graph and be applied via set_graph() calls
- As a result, removed excess shader member pointers they are not needed & prevents crashes
- Added support for textures on rect/quad lights (TODO: need to check if texture co-ords are consistent with other delegates)
- Fixed HDRI co-ordinates on dome/background lights (matches Houdini GL)