### PR TITLE
Improvement: Arbitrary mesh attributes

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -343,6 +343,10 @@ HdCyclesMesh::_AddColors(TfToken name, TfToken role, VtValue colors,
     const bool need_vcol = m_cyclesMesh->need_attribute(scene, vcol_name)
                            || m_cyclesMesh->need_attribute(scene, vcol_std);
 
+    // TODO: Maybe we move this to _PopulateAttributes as well?
+    // seems generic enough. Although different types (uv/vel/cols)
+    // require different handling...
+
     ccl::TypeDesc ctype;
 
     ccl::AttributeElement celem = ccl::ATTR_ELEMENT_NONE;
@@ -381,7 +385,6 @@ HdCyclesMesh::_AddColors(TfToken name, TfToken role, VtValue colors,
                || colors.IsHolding<VtArray<GfVec4i>>()) {
         ctype = ccl::TypeDesc::TypeVector;
     }
-
 
     ccl::Attribute* vcol_attr = NULL;
     vcol_attr                 = attributes->add(vcol_name, ctype, celem);

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1103,10 +1103,11 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                     // - Colors + other data
 
                     else {
-                        // Add colors to attribute
                         _AddColors(pv.name, pv.role, value, scene,
                                    primvarDescsEntry.first);
 
+                        // This swaps the default_surface to one that uses
+                        // displayColor for diffuse
                         if (pv.name == HdTokens->displayColor) {
                             m_hasVertexColors = true;
                         }

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -130,7 +130,7 @@ protected:
      * @param interpolation 
      */
     void _AddUVSet(TfToken name, VtValue uvs, ccl::Scene* scene,
-                   HdInterpolation interpolation, HdMeshUtil meshUtil);
+                   HdInterpolation interpolation);
 
     /**
      * @brief Add vertex/face normals (Not implemented)
@@ -158,8 +158,7 @@ protected:
      * @param interpolation 
      */
     void _AddColors(TfToken name, TfToken role, VtValue colors,
-                    ccl::Scene* scene, HdInterpolation interpolation,
-                    HdMeshUtil meshUtil);
+                    ccl::Scene* scene, HdInterpolation interpolation);
 
 protected:
     struct PrimvarSource {

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -151,6 +151,7 @@ protected:
 
     /**
      * @brief Add vertex/primitive colors
+     * TODO: This handles more than just colors, we should probably refactor
      * 
      * @param name 
      * @param colors 

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -33,6 +33,7 @@
 #include <pxr/base/gf/vec3i.h>
 #include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/mesh.h>
+#include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/vertexAdjacency.h>
 #include <pxr/pxr.h>
 
@@ -128,8 +129,8 @@ protected:
      * @param uvs 
      * @param interpolation 
      */
-    void _AddUVSet(TfToken name, VtVec2fArray& uvs, ccl::Scene* scene,
-                   HdInterpolation interpolation);
+    void _AddUVSet(TfToken name, VtValue uvs, ccl::Scene* scene,
+                   HdInterpolation interpolation, HdMeshUtil meshUtil);
 
     /**
      * @brief Add vertex/face normals (Not implemented)
@@ -156,8 +157,9 @@ protected:
      * @param scene 
      * @param interpolation 
      */
-    void _AddColors(TfToken name, VtVec3fArray& colors, ccl::Scene* scene,
-                    HdInterpolation interpolation);
+    void _AddColors(TfToken name, TfToken role, VtValue colors,
+                    ccl::Scene* scene, HdInterpolation interpolation,
+                    HdMeshUtil meshUtil);
 
 protected:
     struct PrimvarSource {
@@ -263,6 +265,8 @@ protected:
     int m_numNgons;
     int m_numCorners;
 
+    int m_numTriFaces;
+
     Hd_VertexAdjacency m_adjacency;
     bool m_adjacencyValid = false;
 
@@ -302,7 +306,12 @@ protected:
 
     bool m_hasVertexColors;
 
-    ccl::vector<ccl::Shader *> m_usedShaders;
+    ccl::vector<ccl::Shader*> m_usedShaders;
+
+public:
+    const VtIntArray& GetFaceVertexCounts() { return m_faceVertexCounts; }
+    const VtIntArray& GetFaceVertexIndices() { return m_faceVertexIndices; }
+    const TfToken& GetOrientation() { return m_orientation; }
 
 private:
     HdCyclesRenderDelegate* m_renderDelegate;

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -550,101 +550,101 @@ HdCyclesIsPrimvarExists(TfToken const& a_name,
 }
 
 template<>
-float
-to_cycles<float>(const float& v)
+inline float
+to_cycles<float>(const float& v) noexcept
 {
     return v;
 }
 template<>
-float
-to_cycles<double>(const double& v)
+inline float
+to_cycles<double>(const double& v) noexcept
 {
     return static_cast<float>(v);
 }
 template<>
-float
-to_cycles<int>(const int& v)
+inline float
+to_cycles<int>(const int& v) noexcept
 {
     return static_cast<float>(v);
 }
 
 
 template<>
-ccl::float2
-to_cycles<GfVec2f>(const GfVec2f& v)
+inline ccl::float2
+to_cycles<GfVec2f>(const GfVec2f& v) noexcept
 {
     return ccl::make_float2(v[0], v[1]);
 }
 template<>
-ccl::float2
-to_cycles<GfVec2h>(const GfVec2h& v)
+inline ccl::float2
+to_cycles<GfVec2h>(const GfVec2h& v) noexcept
 {
     return ccl::make_float2(static_cast<float>(v[0]), static_cast<float>(v[1]));
 }
 template<>
-ccl::float2
-to_cycles<GfVec2d>(const GfVec2d& v)
+inline ccl::float2
+to_cycles<GfVec2d>(const GfVec2d& v) noexcept
 {
     return ccl::make_float2(static_cast<float>(v[0]), static_cast<float>(v[1]));
 }
 template<>
-ccl::float2
-to_cycles<GfVec2i>(const GfVec2i& v)
+inline ccl::float2
+to_cycles<GfVec2i>(const GfVec2i& v) noexcept
 {
     return ccl::make_float2(static_cast<float>(v[0]), static_cast<float>(v[1]));
 }
 
 template<>
-ccl::float3
-to_cycles<GfVec3f>(const GfVec3f& v)
+inline ccl::float3
+to_cycles<GfVec3f>(const GfVec3f& v) noexcept
 {
     return ccl::make_float3(v[0], v[1], v[2]);
 }
 template<>
-ccl::float3
-to_cycles<GfVec3h>(const GfVec3h& v)
+inline ccl::float3
+to_cycles<GfVec3h>(const GfVec3h& v) noexcept
 {
     return ccl::make_float3(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]));
 }
 template<>
-ccl::float3
-to_cycles<GfVec3d>(const GfVec3d& v)
+inline ccl::float3
+to_cycles<GfVec3d>(const GfVec3d& v) noexcept
 {
     return ccl::make_float3(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]));
 }
 template<>
-ccl::float3
-to_cycles<GfVec3i>(const GfVec3i& v)
+inline ccl::float3
+to_cycles<GfVec3i>(const GfVec3i& v) noexcept
 {
     return ccl::make_float3(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]));
 }
 
 template<>
-ccl::float4
-to_cycles<GfVec4f>(const GfVec4f& v)
+inline ccl::float4
+to_cycles<GfVec4f>(const GfVec4f& v) noexcept
 {
     return ccl::make_float4(v[0], v[1], v[2], v[3]);
 }
 template<>
-ccl::float4
-to_cycles<GfVec4h>(const GfVec4h& v)
+inline ccl::float4
+to_cycles<GfVec4h>(const GfVec4h& v) noexcept
 {
     return ccl::make_float4(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]), static_cast<float>(v[3]));
 }
 template<>
-ccl::float4
-to_cycles<GfVec4d>(const GfVec4d& v)
+inline ccl::float4
+to_cycles<GfVec4d>(const GfVec4d& v) noexcept
 {
     return ccl::make_float4(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]), static_cast<float>(v[3]));
 }
 template<>
-ccl::float4
-to_cycles<GfVec4i>(const GfVec4i& v)
+inline ccl::float4
+to_cycles<GfVec4i>(const GfVec4i& v) noexcept
 {
     return ccl::make_float4(static_cast<float>(v[0]), static_cast<float>(v[1]),
                             static_cast<float>(v[2]), static_cast<float>(v[3]));

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -301,6 +301,18 @@ vec2f_to_float2(const GfVec2f& a_vec)
 }
 
 ccl::float2
+vec2i_to_float2(const GfVec2i& a_vec)
+{
+    return ccl::make_float2((float)a_vec[0], (float)a_vec[1]);
+}
+
+ccl::float2
+vec2d_to_float2(const GfVec2d& a_vec)
+{
+    return ccl::make_float2((float)a_vec[0], (float)a_vec[1]);
+}
+
+ccl::float2
 vec3f_to_float2(const GfVec3f& a_vec)
 {
     return ccl::make_float2(a_vec[0], a_vec[1]);
@@ -322,6 +334,18 @@ ccl::float3
 vec3f_to_float3(const GfVec3f& a_vec)
 {
     return ccl::make_float3(a_vec[0], a_vec[1], a_vec[2]);
+}
+
+ccl::float3
+vec3i_to_float3(const GfVec3i& a_vec)
+{
+    return ccl::make_float3((float)a_vec[0], (float)a_vec[1], (float)a_vec[2]);
+}
+
+ccl::float3
+vec3d_to_float3(const GfVec3d& a_vec)
+{
+    return ccl::make_float3((float)a_vec[0], (float)a_vec[1], (float)a_vec[2]);
 }
 
 ccl::float3
@@ -352,6 +376,20 @@ ccl::float4
 vec4f_to_float4(const GfVec4f& a_vec)
 {
     return ccl::make_float4(a_vec[0], a_vec[1], a_vec[2], a_vec[3]);
+}
+
+ccl::float4
+vec4i_to_float4(const GfVec4i& a_vec)
+{
+    return ccl::make_float4((float)a_vec[0], (float)a_vec[1], (float)a_vec[2],
+                            (float)a_vec[3]);
+}
+
+ccl::float4
+vec4d_to_float4(const GfVec4d& a_vec)
+{
+    return ccl::make_float4((float)a_vec[0], (float)a_vec[1], (float)a_vec[2],
+                            (float)a_vec[3]);
 }
 
 /* ========= Primvars ========= */
@@ -491,169 +529,135 @@ HdCyclesIsPrimvarExists(TfToken const& a_name,
 void
 _PopulateAttribute(const TfToken& name, const TfToken& role,
                    HdInterpolation interpolation, const VtValue& value,
-                   ccl::Attribute* attr, HdMeshUtil meshUtil,
-                   HdCyclesMesh* mesh)
+                   ccl::Attribute* attr, HdCyclesMesh* mesh)
 {
     // Done this way to 'future-proof' and allow arbitrary number of components
     // This might be useless, but felt prudent
     int num_components = -1;
 
+    // We can probably deduce types and sizes from the Gf/Vt API
+    // but for now we handle every permutation.
     VtFloatArray colorVec1f;
     VtVec2fArray colorVec2f;
     VtVec3fArray colorVec3f;
     VtVec4fArray colorVec4f;
 
+    VtDoubleArray colorVec1d;
+    VtVec2dArray colorVec2d;
+    VtVec3dArray colorVec3d;
+    VtVec4dArray colorVec4d;
+
+    VtIntArray colorVec1i;
+    VtVec2iArray colorVec2i;
+    VtVec3iArray colorVec3i;
+    VtVec4iArray colorVec4i;
+
+    // 0 float, 1 double, 2 int
+    int src_type = 0;
+
     if (value.IsHolding<VtArray<float>>()) {
         colorVec1f     = value.UncheckedGet<VtArray<float>>();
         num_components = 1;
+        src_type       = 0;
     } else if (value.IsHolding<VtArray<GfVec2f>>()) {
         colorVec2f     = value.UncheckedGet<VtArray<GfVec2f>>();
         num_components = 2;
+        src_type       = 0;
     } else if (value.IsHolding<VtArray<GfVec3f>>()) {
         colorVec3f     = value.UncheckedGet<VtArray<GfVec3f>>();
         num_components = 3;
+        src_type       = 0;
     } else if (value.IsHolding<VtArray<GfVec4f>>()) {
         colorVec4f     = value.UncheckedGet<VtArray<GfVec4f>>();
         num_components = 4;
+        src_type       = 0;
+    } else if (value.IsHolding<VtArray<double>>()) {
+        colorVec1d     = value.UncheckedGet<VtArray<double>>();
+        num_components = 1;
+        src_type       = 1;
+    } else if (value.IsHolding<VtArray<GfVec2d>>()) {
+        colorVec2d     = value.UncheckedGet<VtArray<GfVec2d>>();
+        num_components = 2;
+        src_type       = 1;
+    } else if (value.IsHolding<VtArray<GfVec3d>>()) {
+        colorVec3d     = value.UncheckedGet<VtArray<GfVec3d>>();
+        num_components = 3;
+        src_type       = 1;
+    } else if (value.IsHolding<VtArray<GfVec4d>>()) {
+        colorVec4d     = value.UncheckedGet<VtArray<GfVec4d>>();
+        num_components = 4;
+        src_type       = 1;
+    } else if (value.IsHolding<VtArray<int>>()) {
+        colorVec1i     = value.UncheckedGet<VtArray<int>>();
+        num_components = 1;
+        src_type       = 2;
+    } else if (value.IsHolding<VtArray<GfVec2i>>()) {
+        colorVec2i     = value.UncheckedGet<VtArray<GfVec2i>>();
+        num_components = 2;
+        src_type       = 2;
+    } else if (value.IsHolding<VtArray<GfVec3i>>()) {
+        colorVec3i     = value.UncheckedGet<VtArray<GfVec3i>>();
+        num_components = 3;
+        src_type       = 2;
+    } else if (value.IsHolding<VtArray<GfVec4f>>()) {
+        colorVec4f     = value.UncheckedGet<VtArray<GfVec4f>>();
+        num_components = 4;
+        src_type       = 2;
     } else {
         std::cout
             << "Invalid color size. Only float, vec2, vec3, and vec4 are supported. Found"
             << value.GetTypeName() << "\n";
     }
 
-    std::cout << "vec" << num_components << '\n';
-    if (interpolation == HdInterpolationFaceVarying) {
-        VtValue triangulated;
-        if (num_components == 1) {
-            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(colorVec1f.data(),
-                                                           colorVec1f.size(),
-                                                           HdTypeFloat,
-                                                           &triangulated);
-            colorVec1f = triangulated.Get<VtFloatArray>();
-        } else if (num_components == 2) {
-            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(colorVec2f.data(),
-                                                           colorVec2f.size(),
-                                                           HdTypeFloatVec2,
-                                                           &triangulated);
-            colorVec2f = triangulated.Get<VtVec2fArray>();
-        } else if (num_components == 3) {
-            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(colorVec3f.data(),
-                                                           colorVec3f.size(),
-                                                           HdTypeFloatVec3,
-                                                           &triangulated);
-            colorVec3f = triangulated.Get<VtVec3fArray>();
-        } else if (num_components == 4) {
-            meshUtil.ComputeTriangulatedFaceVaryingPrimvar(colorVec4f.data(),
-                                                           colorVec4f.size(),
-                                                           HdTypeFloatVec4,
-                                                           &triangulated);
-            colorVec4f = triangulated.Get<VtVec4fArray>();
-        }
-    }
-
-
-    std::cout << "GGGGGGG: " << name << '\n';
-    std::cout << "FFFFFFF: " << role << '\n';
+    size_t arr_size  = value.GetArraySize();
     char* data       = attr->data();
     size_t data_size = sizeof(ccl::uchar4);
-    if (role != HdPrimvarRoleTokens->color) {
-        if (num_components == 1)
-            data_size += sizeof(float);
-        else if (num_components == 2)
-            data_size += sizeof(ccl::float2);
-        else if (num_components == 3)
-            data_size += sizeof(ccl::float3);
-        else if (num_components == 4)
-            data_size += sizeof(ccl::float4);
-    }
 
-    std::cout << " data_size " << data_size << '\n';
+    if (num_components == 1)
+        data_size = sizeof(float);
+    else if (num_components == 2)
+        data_size = sizeof(ccl::float2);
+    else if (num_components == 3)
+        data_size = sizeof(ccl::float3);
+    else if (num_components == 4)
+        data_size = sizeof(ccl::float4);
 
     if (interpolation == HdInterpolationVertex) {
         VtIntArray::const_iterator idxIt = mesh->GetFaceVertexIndices().begin();
 
-        // TODO: Add support for subd faces?
-        for (int i = 0; i < mesh->GetFaceVertexCounts().size(); i++) {
-            const int vCount = mesh->GetFaceVertexCounts()[i];
+        for (int i = 0; i < value.GetArraySize(); i++) {
+            if (num_components == 1) {
+                if (src_type == 0)
+                    ((float*)data)[0] = colorVec1f[i];
+                else if (src_type == 1)
+                    ((float*)data)[0] = (float)colorVec1d[i];
+                else if (src_type == 2)
+                    ((float*)data)[0] = (float)colorVec1i[i];
+            } else if (num_components == 2) {
+                if (src_type == 0)
+                    ((ccl::float2*)data)[0] = vec2f_to_float2(colorVec2f[i]);
+                else if (src_type == 1)
+                    ((ccl::float2*)data)[0] = vec2d_to_float2(colorVec2d[i]);
+                else if (src_type == 2)
+                    ((ccl::float2*)data)[0] = vec2i_to_float2(colorVec2i[i]);
 
-            for (int j = 1; j < vCount - 1; ++j) {
-                int v0 = *idxIt;
-                int v1 = *(idxIt + j + 0);
-                int v2 = *(idxIt + j + 1);
+            } else if (num_components == 3) {
+                if (src_type == 0)
+                    ((ccl::float3*)data)[0] = vec3f_to_float3(colorVec3f[i]);
+                else if (src_type == 1)
+                    ((ccl::float3*)data)[0] = vec3d_to_float3(colorVec3d[i]);
+                else if (src_type == 2)
+                    ((ccl::float3*)data)[0] = vec3i_to_float3(colorVec3i[i]);
 
-                if (mesh->GetOrientation() == HdTokens->leftHanded) {
-                    v1 = *(idxIt + j + 1);
-                    v2 = *(idxIt + j + 0);
-                }
-
-                if (num_components == 1) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec1f_to_float4(colorVec1f[v0]));
-                        ((ccl::uchar4*)data)[1] = ccl::color_float4_to_uchar4(
-                            vec1f_to_float4(colorVec1f[v1]));
-                        ((ccl::uchar4*)data)[2] = ccl::color_float4_to_uchar4(
-                            vec1f_to_float4(colorVec1f[v2]));
-                    } else {
-                        ((float*)data)[0] = colorVec1f[v0];
-                        ((float*)data)[1] = colorVec1f[v1];
-                        ((float*)data)[2] = colorVec1f[v2];
-                    }
-                    data += (3 * data_size);
-                } else if (num_components == 2) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec2f_to_float4(colorVec2f[v0]));
-                        ((ccl::uchar4*)data)[1] = ccl::color_float4_to_uchar4(
-                            vec2f_to_float4(colorVec2f[v1]));
-                        ((ccl::uchar4*)data)[2] = ccl::color_float4_to_uchar4(
-                            vec2f_to_float4(colorVec2f[v2]));
-                    } else {
-                        ((ccl::float2*)data)[0] = vec2f_to_float2(
-                            colorVec2f[v0]);
-                        ((ccl::float2*)data)[1] = vec2f_to_float2(
-                            colorVec2f[v1]);
-                        ((ccl::float2*)data)[2] = vec2f_to_float2(
-                            colorVec2f[v2]);
-                    }
-                    data += (3 * data_size);
-                } else if (num_components == 3) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec3f_to_float4(colorVec3f[v0]));
-                        ((ccl::uchar4*)data)[1] = ccl::color_float4_to_uchar4(
-                            vec3f_to_float4(colorVec3f[v1]));
-                        ((ccl::uchar4*)data)[2] = ccl::color_float4_to_uchar4(
-                            vec3f_to_float4(colorVec3f[v2]));
-                    } else {
-                        ((ccl::float3*)data)[0] = vec3f_to_float3(
-                            colorVec3f[v0]);
-                        ((ccl::float3*)data)[1] = vec3f_to_float3(
-                            colorVec3f[v1]);
-                        ((ccl::float3*)data)[2] = vec3f_to_float3(
-                            colorVec3f[v2]);
-                    }
-                    data += (3 * data_size);
-                } else if (num_components == 4) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec4f_to_float4(colorVec4f[v0]));
-                        ((ccl::uchar4*)data)[1] = ccl::color_float4_to_uchar4(
-                            vec4f_to_float4(colorVec4f[v1]));
-                        ((ccl::uchar4*)data)[2] = ccl::color_float4_to_uchar4(
-                            vec4f_to_float4(colorVec4f[v2]));
-                    } else {
-                        ((ccl::float4*)data)[0] = vec4f_to_float4(
-                            colorVec4f[v0]);
-                        ((ccl::float4*)data)[1] = vec4f_to_float4(
-                            colorVec4f[v1]);
-                        ((ccl::float4*)data)[2] = vec4f_to_float4(
-                            colorVec4f[v2]);
-                    }
-                    data += (3 * data_size);
-                }
+            } else if (num_components == 4) {
+                if (src_type == 0)
+                    ((ccl::float4*)data)[0] = vec4f_to_float4(colorVec4f[i]);
+                else if (src_type == 1)
+                    ((ccl::float4*)data)[0] = vec4d_to_float4(colorVec4d[i]);
+                else if (src_type == 2)
+                    ((ccl::float4*)data)[0] = vec4i_to_float4(colorVec4i[i]);
             }
-            idxIt += vCount;
+            data += 1 * data_size;
         }
 
     } else if (interpolation == HdInterpolationUniform) {
@@ -664,101 +668,196 @@ _PopulateAttribute(const TfToken& name, const TfToken& role,
             }
             const int vCount = mesh->GetFaceVertexCounts()[i];
 
-            int subTris = (vCount - 2) * 3;
+            int subTris = (vCount - 2);
 
-            if (num_components == 1) {
-                for (size_t j = 0; j < subTris; j++) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec1f_to_float4(colorVec1f[i]));
-                    } else {
+            for (size_t j = 0; j < subTris; j++) {
+                if (num_components == 1) {
+                    if (src_type == 0)
                         ((float*)data)[0] = colorVec1f[i];
-                    }
-                    data += 1 * data_size;
-                }
-            } else if (num_components == 2) {
-                for (size_t j = 0; j < subTris; j++) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec2f_to_float4(colorVec2f[i]));
-                    } else {
+                    else if (src_type == 1)
+                        ((float*)data)[0] = (float)colorVec1d[i];
+                    else if (src_type == 2)
+                        ((float*)data)[0] = (float)colorVec1i[i];
+
+                } else if (num_components == 2) {
+                    if (src_type == 0)
                         ((ccl::float2*)data)[0] = vec2f_to_float2(
                             colorVec2f[i]);
-                    }
-                    data += 1 * data_size;
-                }
-            } else if (num_components == 3) {
-                for (size_t j = 0; j < subTris; j++) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec3f_to_float4(colorVec3f[i]));
-                    } else {
+                    else if (src_type == 1)
+                        ((ccl::float2*)data)[0] = vec2d_to_float2(
+                            colorVec2d[i]);
+                    else if (src_type == 2)
+                        ((ccl::float2*)data)[0] = vec2i_to_float2(
+                            colorVec2i[i]);
+
+                } else if (num_components == 3) {
+                    if (src_type == 0)
                         ((ccl::float3*)data)[0] = vec3f_to_float3(
                             colorVec3f[i]);
-                    }
-                    data += 1 * data_size;
-                }
-            } else if (num_components == 4) {
-                for (size_t j = 0; j < subTris; j++) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec4f_to_float4(colorVec4f[i]));
-                    } else {
+                    else if (src_type == 1)
+                        ((ccl::float3*)data)[0] = vec3d_to_float3(
+                            colorVec3d[i]);
+                    else if (src_type == 2)
+                        ((ccl::float3*)data)[0] = vec3i_to_float3(
+                            colorVec3i[i]);
+
+                } else if (num_components == 4) {
+                    if (src_type == 0)
                         ((ccl::float4*)data)[0] = vec4f_to_float4(
                             colorVec4f[i]);
-                    }
-                    data += 1 * data_size;
+                    else if (src_type == 1)
+                        ((ccl::float4*)data)[0] = vec4d_to_float4(
+                            colorVec4d[i]);
+                    else if (src_type == 2)
+                        ((ccl::float4*)data)[0] = vec4i_to_float4(
+                            colorVec4i[i]);
                 }
+                data += 1 * data_size;
             }
         }
     } else if (interpolation == HdInterpolationFaceVarying) {
-        int idx = 0;
-
+        int count = 0;
         for (int i = 0; i < mesh->GetFaceVertexCounts().size(); i++) {
             const int vCount = mesh->GetFaceVertexCounts()[i];
-            int subTris      = (vCount - 2) * 3;
 
-            for (int j = 0; j < subTris; j++) {
-                if (num_components == 1) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec1f_to_float4(colorVec1f[idx]));
-                    } else {
-                        ((float*)data)[0] = colorVec1f[idx];
-                    }
-                    data += 1 * data_size;
-                } else if (num_components == 2) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec2f_to_float4(colorVec2f[idx]));
-                    } else {
-                        //std::cout << "vec2 facevarying << convert\n";
-                        ((ccl::float2*)data)[0] = vec2f_to_float2(
-                            colorVec2f[idx]);
-                    }
-                    data += 1 * data_size;
-                } else if (num_components == 3) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec3f_to_float4(colorVec3f[idx]));
-                    } else {
-                        ((ccl::float3*)data)[0] = vec3f_to_float3(
-                            colorVec3f[idx]);
-                    }
-                    data += 1 * data_size;
-                } else if (num_components == 4) {
-                    if (role == HdPrimvarRoleTokens->color) {
-                        ((ccl::uchar4*)data)[0] = ccl::color_float4_to_uchar4(
-                            vec4f_to_float4(colorVec4f[idx]));
-                    } else {
-                        ((ccl::float4*)data)[0] = vec4f_to_float4(
-                            colorVec4f[idx]);
-                    }
-                    data += 1 * data_size;
+            for (int j = 1; j < vCount - 1; ++j) {
+                int v0 = count;
+                int v1 = (count + j + 0);
+                int v2 = (count + j + 1);
+
+                if (mesh->GetOrientation() == HdTokens->leftHanded) {
+                    v1 = (count + ((vCount - 1) - j) + 0);
+                    v2 = (count + ((vCount - 1) - j) + 1);
                 }
-                idx += 1;
+
+                if (num_components == 1) {
+                    if (src_type == 0) {
+                        ((float*)data)[0] = colorVec1f[v0];
+                        ((float*)data)[1] = colorVec1f[v1];
+                        ((float*)data)[2] = colorVec1f[v2];
+                    } else if (src_type == 1) {
+                        ((float*)data)[0] = (float)colorVec1d[v0];
+                        ((float*)data)[1] = (float)colorVec1d[v1];
+                        ((float*)data)[2] = (float)colorVec1d[v2];
+                    } else if (src_type == 2) {
+                        ((float*)data)[0] = (float)colorVec1i[v0];
+                        ((float*)data)[1] = (float)colorVec1i[v1];
+                        ((float*)data)[2] = (float)colorVec1i[v2];
+                    }
+                } else if (num_components == 2) {
+                    if (src_type == 0) {
+                        ((ccl::float2*)data)[0] = vec2f_to_float2(
+                            colorVec2f[v0]);
+                        ((ccl::float2*)data)[1] = vec2f_to_float2(
+                            colorVec2f[v1]);
+                        ((ccl::float2*)data)[2] = vec2f_to_float2(
+                            colorVec2f[v2]);
+                    } else if (src_type == 1) {
+                        ((ccl::float2*)data)[0] = vec2d_to_float2(
+                            colorVec2d[v0]);
+                        ((ccl::float2*)data)[1] = vec2d_to_float2(
+                            colorVec2d[v1]);
+                        ((ccl::float2*)data)[2] = vec2d_to_float2(
+                            colorVec2d[v2]);
+                    } else if (src_type == 2) {
+                        ((ccl::float2*)data)[0] = vec2i_to_float2(
+                            colorVec2i[v0]);
+                        ((ccl::float2*)data)[1] = vec2i_to_float2(
+                            colorVec2i[v1]);
+                        ((ccl::float2*)data)[2] = vec2i_to_float2(
+                            colorVec2i[v2]);
+                    }
+
+                } else if (num_components == 3) {
+                    if (src_type == 0) {
+                        ((ccl::float3*)data)[0] = vec3f_to_float3(
+                            colorVec3f[v0]);
+                        ((ccl::float3*)data)[1] = vec3f_to_float3(
+                            colorVec3f[v1]);
+                        ((ccl::float3*)data)[2] = vec3f_to_float3(
+                            colorVec3f[v2]);
+                    } else if (src_type == 1) {
+                        ((ccl::float3*)data)[0] = vec3d_to_float3(
+                            colorVec3d[v0]);
+                        ((ccl::float3*)data)[1] = vec3d_to_float3(
+                            colorVec3d[v1]);
+                        ((ccl::float3*)data)[2] = vec3d_to_float3(
+                            colorVec3d[v2]);
+                    } else if (src_type == 2) {
+                        ((ccl::float3*)data)[0] = vec3i_to_float3(
+                            colorVec3i[v0]);
+                        ((ccl::float3*)data)[1] = vec3i_to_float3(
+                            colorVec3i[v1]);
+                        ((ccl::float3*)data)[2] = vec3i_to_float3(
+                            colorVec3i[v2]);
+                    }
+
+                } else if (num_components == 4) {
+                    if (src_type == 0) {
+                        ((ccl::float4*)data)[0] = vec4f_to_float4(
+                            colorVec4f[v0]);
+                        ((ccl::float4*)data)[1] = vec4f_to_float4(
+                            colorVec4f[v1]);
+                        ((ccl::float4*)data)[2] = vec4f_to_float4(
+                            colorVec4f[v2]);
+                    } else if (src_type == 1) {
+                        ((ccl::float4*)data)[0] = vec4d_to_float4(
+                            colorVec4d[v0]);
+                        ((ccl::float4*)data)[1] = vec4d_to_float4(
+                            colorVec4d[v1]);
+                        ((ccl::float4*)data)[2] = vec4d_to_float4(
+                            colorVec4d[v2]);
+                    } else if (src_type == 2) {
+                        ((ccl::float4*)data)[0] = vec4i_to_float4(
+                            colorVec4i[v0]);
+                        ((ccl::float4*)data)[1] = vec4i_to_float4(
+                            colorVec4i[v1]);
+                        ((ccl::float4*)data)[2] = vec4i_to_float4(
+                            colorVec4i[v2]);
+                    }
+                }
+                data += 3 * data_size;
+            }
+            count += vCount;
+        }
+    } else if (interpolation == HdInterpolationConstant) {
+        if (value.GetArraySize() > 0) {
+            if (num_components == 1) {
+                if (src_type == 0)
+                    ((float*)data)[0] = colorVec1f[0];
+                else if (src_type == 1)
+                    ((float*)data)[0] = (float)colorVec1d[0];
+                else if (src_type == 2)
+                    ((float*)data)[0] = (float)colorVec1i[0];
+
+            } else if (num_components == 2) {
+                if (src_type == 0)
+                    ((ccl::float2*)data)[0] = vec2f_to_float2(colorVec2f[0]);
+                else if (src_type == 1)
+                    ((ccl::float2*)data)[0] = vec2d_to_float2(colorVec2d[0]);
+                else if (src_type == 2)
+                    ((ccl::float2*)data)[0] = vec2i_to_float2(colorVec2i[0]);
+
+            } else if (num_components == 3) {
+                if (src_type == 0)
+                    ((ccl::float3*)data)[0] = vec3f_to_float3(colorVec3f[0]);
+                else if (src_type == 1)
+                    ((ccl::float3*)data)[0] = vec3d_to_float3(colorVec3d[0]);
+                else if (src_type == 2)
+                    ((ccl::float3*)data)[0] = vec3i_to_float3(colorVec3i[0]);
+
+            } else if (num_components == 4) {
+                if (src_type == 0)
+                    ((ccl::float4*)data)[0] = vec4f_to_float4(colorVec4f[0]);
+                else if (src_type == 1)
+                    ((ccl::float4*)data)[0] = vec4d_to_float4(colorVec4d[0]);
+                else if (src_type == 2)
+                    ((ccl::float4*)data)[0] = vec4i_to_float4(colorVec4i[0]);
             }
         }
+    } else {
+        std::cout << "HdCycles WARNING: Interpolation unsupported: "
+                  << interpolation << '\n';
     }
 }
 

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -43,6 +43,7 @@
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/basisCurves.h>
 #include <pxr/imaging/hd/mesh.h>
+#include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/timeSampleArray.h>
 #include <pxr/pxr.h>
@@ -52,6 +53,8 @@ class Mesh;
 }
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdCyclesMesh;
 
 /* =========- Texture ========== */
 
@@ -198,6 +201,30 @@ ccl::float3
 vec4f_to_float3(const GfVec4f& a_vec);
 
 /**
+ * @brief Convert float to Cycles float4
+ * Fills all components with float
+ *
+ * @param a_vec
+ * @param a_alpha
+ * @return Cycles float4
+ */
+ccl::float4
+vec1f_to_float4(const float& a_vec);
+
+/**
+ * @brief Convert GfVec2f to Cycles float4
+ * Z is set to a default of 0
+ * Alpha is set to a default of 1
+ *
+ * @param a_vec
+ * @param a_z
+ * @param a_alpha
+ * @return Cycles float4
+ */
+ccl::float4
+vec2f_to_float4(const GfVec2f& a_vec, float a_z = 0.0f, float a_alpha = 1.0f);
+
+/**
  * @brief Convert GfVec3f to Cycles float4 representation with alpha option
  *
  * @param a_vec
@@ -269,6 +296,9 @@ using HdCyclesSampledPrimvarType
 
 /* ======== VtValue Utils ========= */
 
+void
+_PopulateAttribute(const TfToken& name, const TfToken& role, HdInterpolation interpolation, const VtValue& value,
+                   ccl::Attribute* attr, HdMeshUtil meshUtil, HdCyclesMesh* mesh);
 
 template<typename F>
 void

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -43,7 +43,6 @@
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/basisCurves.h>
 #include <pxr/imaging/hd/mesh.h>
-#include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/timeSampleArray.h>
 #include <pxr/pxr.h>
@@ -156,6 +155,24 @@ ccl::float2
 vec2f_to_float2(const GfVec2f& a_vec);
 
 /**
+ * @brief Convert GfVec2i to Cycles float2 representation
+ *
+ * @param a_vec
+ * @return Cycles float2
+ */
+ccl::float2
+vec2i_to_float2(const GfVec2i& a_vec);
+
+/**
+ * @brief Convert GfVec2d to Cycles float2 representation
+ *
+ * @param a_vec
+ * @return Cycles float2
+ */
+ccl::float2
+vec2d_to_float2(const GfVec2d& a_vec);
+
+/**
  * @brief Convert GfVec3f to Cycles float2 representation
  *
  * @param a_vec
@@ -190,6 +207,24 @@ vec2f_to_float3(const GfVec2f& a_vec);
  */
 ccl::float3
 vec3f_to_float3(const GfVec3f& a_vec);
+
+/**
+ * @brief Convert GfVec3i to Cycles float3 representation
+ *
+ * @param a_vec
+ * @return Cycles float3
+ */
+ccl::float3
+vec3i_to_float3(const GfVec3i& a_vec);
+
+/**
+ * @brief Convert GfVec3d to Cycles float3 representation
+ *
+ * @param a_vec
+ * @return Cycles float3
+ */
+ccl::float3
+vec3d_to_float3(const GfVec3d& a_vec);
 
 /**
  * @brief Lossy convert GfVec4f to Cycles float3 representation
@@ -299,8 +334,7 @@ using HdCyclesSampledPrimvarType
 void
 _PopulateAttribute(const TfToken& name, const TfToken& role,
                    HdInterpolation interpolation, const VtValue& value,
-                   ccl::Attribute* attr, HdMeshUtil meshUtil,
-                   HdCyclesMesh* mesh);
+                   ccl::Attribute* attr, HdCyclesMesh* mesh);
 
 template<typename F>
 void

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -297,8 +297,10 @@ using HdCyclesSampledPrimvarType
 /* ======== VtValue Utils ========= */
 
 void
-_PopulateAttribute(const TfToken& name, const TfToken& role, HdInterpolation interpolation, const VtValue& value,
-                   ccl::Attribute* attr, HdMeshUtil meshUtil, HdCyclesMesh* mesh);
+_PopulateAttribute(const TfToken& name, const TfToken& role,
+                   HdInterpolation interpolation, const VtValue& value,
+                   ccl::Attribute* attr, HdMeshUtil meshUtil,
+                   HdCyclesMesh* mesh);
 
 template<typename F>
 void

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -146,59 +146,59 @@ mat4f_to_transform(const GfMatrix4f& mat);
 
 
 template<typename T, typename U>
-U
-to_cycles(const T& vec)
+inline U
+to_cycles(const T& vec) noexcept
 {
 }
 
 template<>
-float
-to_cycles<float, float>(const float& v);
+inline float
+to_cycles<float, float>(const float& v) noexcept;
 template<>
-float
-to_cycles<double, float>(const double& v);
+inline float
+to_cycles<double, float>(const double& v) noexcept;
 template<>
-float
-to_cycles<int, float>(const int& v);
+inline float
+to_cycles<int, float>(const int& v) noexcept;
 
 template<>
-ccl::float2
-to_cycles<GfVec2f, ccl::float2>(const GfVec2f& v);
+inline ccl::float2
+to_cycles<GfVec2f, ccl::float2>(const GfVec2f& v) noexcept;
 template<>
-ccl::float2
-to_cycles<GfVec2h, ccl::float2>(const GfVec2h& v);
+inline ccl::float2
+to_cycles<GfVec2h, ccl::float2>(const GfVec2h& v) noexcept;
 template<>
-ccl::float2
-to_cycles<GfVec2d, ccl::float2>(const GfVec2d& v);
+inline ccl::float2
+to_cycles<GfVec2d, ccl::float2>(const GfVec2d& v) noexcept;
 template<>
-ccl::float2
-to_cycles<GfVec2i, ccl::float2>(const GfVec2i& v);
+inline ccl::float2
+to_cycles<GfVec2i, ccl::float2>(const GfVec2i& v) noexcept;
 
 template<>
-ccl::float3
-to_cycles<GfVec3f, ccl::float3>(const GfVec3f& v);
+inline ccl::float3
+to_cycles<GfVec3f, ccl::float3>(const GfVec3f& v) noexcept;
 template<>
-ccl::float3
-to_cycles<GfVec3h, ccl::float3>(const GfVec3h& v);
+inline ccl::float3
+to_cycles<GfVec3h, ccl::float3>(const GfVec3h& v) noexcept;
 template<>
-ccl::float3
-to_cycles<GfVec3d, ccl::float3>(const GfVec3d& v);
+inline ccl::float3
+to_cycles<GfVec3d, ccl::float3>(const GfVec3d& v) noexcept;
 template<>
-ccl::float3
-to_cycles<GfVec3i, ccl::float3>(const GfVec3i& v);
+inline ccl::float3
+to_cycles<GfVec3i, ccl::float3>(const GfVec3i& v) noexcept;
 
 template<>
-ccl::float4
-to_cycles<GfVec3f, ccl::float4>(const GfVec3f& v);
+inline ccl::float4
+to_cycles<GfVec3f, ccl::float4>(const GfVec3f& v) noexcept;
 template<>
-ccl::float4
-to_cycles<GfVec3h, ccl::float4>(const GfVec3h& v);
+inline ccl::float4
+to_cycles<GfVec3h, ccl::float4>(const GfVec3h& v) noexcept;
 template<>
-ccl::float4
-to_cycles<GfVec3d, ccl::float4>(const GfVec3d& v);
+inline ccl::float4
+to_cycles<GfVec3d, ccl::float4>(const GfVec3d& v) noexcept;
 template<>
-ccl::float4
-to_cycles<GfVec3i, ccl::float4>(const GfVec3i& v);
+inline ccl::float4
+to_cycles<GfVec3i, ccl::float4>(const GfVec3i& v) noexcept;
 
 /**
  * @brief Convert GfVec2i to Cycles int2 representation

--- a/plugin/ndrCycles/discovery.cpp
+++ b/plugin/ndrCycles/discovery.cpp
@@ -70,6 +70,7 @@ NdrCyclesDiscoveryPlugin::DiscoverNodes(const Context& context)
     temp_nodes.push_back("principled_volume");
     temp_nodes.push_back("scatter_volume");
     temp_nodes.push_back("absorption_volume");
+    temp_nodes.push_back("emission");
 
     for (const std::string& n : temp_nodes) {
         std::string cycles_id = std::string("cycles_" + n);


### PR DESCRIPTION
This PR is a step towards a more generic way of populating Cycles attributes from meshes.

This does not touch curves or other attributes. It eventually should be agnostic to all. 