### PR TITLE
remove pxr namespace

### DIFF
--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -418,11 +418,11 @@ convertCyclesNode(HdMaterialNode& usd_node,
                 } else if (params.second.IsHolding<TfToken>()) {
                     val = params.second.Get<TfToken>().GetString().c_str();
                     if (val.length() > 0)
-                        val = pxr::TfMakeValidIdentifier(val);
+                        val = TfMakeValidIdentifier(val);
                 } else if (params.second.IsHolding<std::string>()) {
                     val = std::string(params.second.Get<std::string>().c_str());
                     if (val.length() > 0)
-                        val = pxr::TfMakeValidIdentifier(val);
+                        val = TfMakeValidIdentifier(val);
                 }
 
                 cyclesNode->set(socket, val.c_str());
@@ -539,7 +539,7 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate,
                         node.path, std::make_pair(&node, cycles_node)));
             }
 
-            for (const pxr::SdfPath& tPath : networkMap.terminals) {
+            for (const SdfPath& tPath : networkMap.terminals) {
                 if (node.path == tPath) {
                     output_node = cycles_node;
 

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -564,8 +564,8 @@ template<typename F>
 void
 _CheckForVec2iValue(const VtValue& value, F&& f)
 {
-    if (value.IsHolding<pxr::GfVec2i>()) {
-        f(value.UncheckedGet<pxr::GfVec2i>());
+    if (value.IsHolding<GfVec2i>()) {
+        f(value.UncheckedGet<GfVec2i>());
     }
 }
 


### PR DESCRIPTION
If USD is compiled without name spaces. `hdCycles` will not compile since `pxr` namespace does not exist. We don't have to use `pxr::` namespace because we are in between `PXR_NAMESPACE_OPEN_SCOPE` `PXR_NAMESPACE_CLOSE_SCOPE`