### PR TITLE
Remove unnecessary define

### DIFF
--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -418,11 +418,11 @@ convertCyclesNode(HdMaterialNode& usd_node,
                 } else if (params.second.IsHolding<TfToken>()) {
                     val = params.second.Get<TfToken>().GetString().c_str();
                     if (val.length() > 0)
-                        val = pxr::TfMakeValidIdentifier(val);
+                        val = TfMakeValidIdentifier(val);
                 } else if (params.second.IsHolding<std::string>()) {
                     val = std::string(params.second.Get<std::string>().c_str());
                     if (val.length() > 0)
-                        val = pxr::TfMakeValidIdentifier(val);
+                        val = TfMakeValidIdentifier(val);
                 }
 
                 cyclesNode->set(socket, val.c_str());
@@ -539,7 +539,7 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate,
                         node.path, std::make_pair(&node, cycles_node)));
             }
 
-            for (const pxr::SdfPath& tPath : networkMap.terminals) {
+            for (const SdfPath& tPath : networkMap.terminals) {
                 if (node.path == tPath) {
                     output_node = cycles_node;
 

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -564,8 +564,8 @@ template<typename F>
 void
 _CheckForVec2iValue(const VtValue& value, F&& f)
 {
-    if (value.IsHolding<pxr::GfVec2i>()) {
-        f(value.UncheckedGet<pxr::GfVec2i>());
+    if (value.IsHolding<GfVec2i>()) {
+        f(value.UncheckedGet<GfVec2i>());
     }
 }
 

--- a/plugin/ndrCycles/parser.cpp
+++ b/plugin/ndrCycles/parser.cpp
@@ -74,6 +74,18 @@ NdrNodeUniquePtr
 NdrCyclesParserPlugin::Parse(const NdrNodeDiscoveryResult& discoveryResult)
 {
     NdrPropertyUniquePtrVec properties;
+#if PXR_MINOR_VERSION >= 20 && PXR_PATCH_VERSION >= 5
+    return NdrNodeUniquePtr(
+        new SdrShaderNode(discoveryResult.identifier,     // identifier
+                            discoveryResult.version,        // version
+                            discoveryResult.name,           // name
+                            discoveryResult.family,         // family
+                            discoveryResult.discoveryType,  // context
+                            discoveryResult.sourceType,     // sourceType
+                            discoveryResult.uri,            // uri
+                            discoveryResult.uri,            // resolvedUri
+                            std::move(properties)));
+#else
     return NdrNodeUniquePtr(
         new SdrShaderNode(discoveryResult.identifier,     // identifier
                           discoveryResult.version,        // version
@@ -82,11 +94,8 @@ NdrCyclesParserPlugin::Parse(const NdrNodeDiscoveryResult& discoveryResult)
                           discoveryResult.discoveryType,  // context
                           discoveryResult.sourceType,     // sourceType
                           discoveryResult.uri,            // uri
-// TODO: Enable this when we move to 20.05
-#ifdef USD_HAS_NEW_SDR_NODE_CONSTRUCTOR
-                          discoveryResult.uri,  // resolvedUri
-#endif
                           std::move(properties)));
+#endif
 }
 
 const NdrTokenVec&


### PR DESCRIPTION
To avoid using custom `USD_HAS_NEW_SDR_NODE_CONSTRUCTOR` define, we can use versioning explicitly.