### PR TITLE
Cleanup: Replaced stdout's with TF_* helpers 

### DIFF
--- a/plugin/hdCycles/config.cpp
+++ b/plugin/hdCycles/config.cpp
@@ -92,9 +92,6 @@ TF_DEFINE_ENV_SETTING(HD_CYCLES_ENABLE_PROGRESS, false,
 TF_DEFINE_ENV_SETTING(HD_CYCLES_USE_TILED_RENDERING, false,
                       "Use Tiled Rendering (Experimental)");
 
-TF_DEFINE_ENV_SETTING(HD_CYCLES_UP_AXIS, "Z",
-                      "Set custom up axis (Z or Y currently supported)");
-
 // HdCycles Constructor
 HdCyclesConfig::HdCyclesConfig()
 {
@@ -111,7 +108,7 @@ HdCyclesConfig::HdCyclesConfig()
     enable_logging  = TfGetEnvSetting(HD_CYCLES_ENABLE_LOGGING);
     enable_progress = TfGetEnvSetting(HD_CYCLES_ENABLE_PROGRESS);
 
-    up_axis = TfGetEnvSetting(HD_CYCLES_UP_AXIS);
+    up_axis = HdCyclesEnvValue<std::string>("HD_CYCLES_UP_AXIS", "Z");
 
     enable_motion_blur = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_MOTION_BLUR",
                                                 false);

--- a/plugin/hdCycles/config.h
+++ b/plugin/hdCycles/config.h
@@ -63,8 +63,7 @@ template<typename T> struct HdCyclesEnvValue {
 
         if (hasOverride) {
             a_previous = value;
-            std::cout << "[" << envName << "] has been set: " << a_previous
-                      << '\n';
+            TF_STATUS("[%s] has been set %s", envName, a_previous);
         }
 
         return hasOverride;
@@ -127,7 +126,7 @@ public:
      * @brief Set custom up axis (Z or Y currently supported)
      *
      */
-    std::string up_axis;
+    HdCyclesEnvValue<std::string> up_axis;
 
     /**
      * @brief If enabled, HdCycles will populate object's motion and enable motion blur

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -358,7 +358,7 @@ convertCyclesNode(HdMaterialNode& usd_node,
                     cyclesNode->set(socket, params.second.Get<bool>());
                 } else if (params.second.IsHolding<int>()) {
                     cyclesNode->set(socket, (bool)params.second.Get<int>());
-                } 
+                }
             } break;
 
             case ccl::SocketType::INT: {
@@ -473,9 +473,9 @@ convertCyclesNode(HdMaterialNode& usd_node,
             } break;
 
             default: {
-                std::cout << "HdCycles unsupported socket type. Node: "
-                          << node_id << " - Socket: " << socket.name.string()
-                          << " - Type: " << socket.type << '\n';
+                TF_WARN(
+                    "HdCycles unsupported socket type. Node: %s - Socket: %s - Type: %s",
+                    node_id, socket.name.string(), socket.type);
             } break;
             }
         }

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -411,9 +411,9 @@ HdCyclesMesh::_AddColors(TfToken name, TfToken role, VtValue colors,
             displayColor = vec4f_to_float4(
                 colors.UncheckedGet<VtArray<GfVec4f>>()[0]);
         } else {
-            std::cout
-                << "Invalid color size. Only float, vec2, vec3, and vec4 are supported. Found"
-                << colors.GetTypeName() << "\n";
+            TF_WARN(
+                "Invalid color size. Only float, vec2, vec3, and vec4 are supported. Found %s.",
+                colors.GetTypeName());
         }
 
         m_cyclesObject->color = ccl::make_float3(displayColor.x, displayColor.y,

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -51,7 +51,7 @@ public:
             file.open();
             this->grid = file.readGrid(grid_name);
         } catch (const openvdb::IoError& e) {
-            std::cout << "LOAD ERROR\n";
+            TF_RUNTIME_ERROR("VDB LOAD ERROR");
         }
     }
 };

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -106,9 +106,9 @@ HdCyclesRenderParam::_InitializeDefaults()
     m_useTiledRendering                 = config.use_tiled_rendering;
 
     m_upAxis = UpAxis::Z;
-    if (config.up_axis == "Z") {
+    if (config.up_axis.value == "Z") {
         m_upAxis = UpAxis::Z;
-    } else if (config.up_axis == "Y") {
+    } else if (config.up_axis.value == "Y") {
         m_upAxis = UpAxis::Y;
     }
 
@@ -185,7 +185,7 @@ HdCyclesRenderParam::Initialize(HdRenderSettingsMap const& settingsMap)
     _UpdateSessionFromConfig();
 
     if (!_CreateSession()) {
-        std::cout << "COULD NOT CREATE CYCLES SESSION\n";
+        TF_RUNTIME_ERROR("COULD NOT CREATE CYCLES SESSION");
         // Couldn't create session, big issue
         return false;
     }
@@ -196,7 +196,7 @@ HdCyclesRenderParam::Initialize(HdRenderSettingsMap const& settingsMap)
     _UpdateSceneFromConfig();
 
     if (!_CreateScene()) {
-        std::cout << "COULD NOT CREATE CYCLES SCENE\n";
+        TF_RUNTIME_ERROR("COULD NOT CREATE CYCLES SCENE\n");
         // Couldn't create scene, big issue
         return false;
     }

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -143,12 +143,14 @@ _DumpGraph(ccl::ShaderGraph* shaderGraph, const char* name)
         std::string dump_location = config.cycles_shader_graph_dump_dir + "/"
                                     + TfMakeValidIdentifier(name)
                                     + "_graph.txt";
-        std::cout << "Dumping shader graph: " << dump_location << '\n';
+
+        TF_STATUS("Dumping shader graph: %s", dump_location);
+
         try {
             shaderGraph->dump_graph(dump_location.c_str());
             return true;
         } catch (...) {
-            std::cout << "Couldn't dump shadergraph: " << dump_location << "\n";
+            TF_WARN("Couldn't dump shadergraph: %s", dump_location);
         }
     }
     return false;
@@ -737,8 +739,7 @@ _PopulateAttribte_Constant(const VtValue& value, ccl::Attribute* attr)
     VtArray<T> usd_data = value.UncheckedGet<VtArray<T>>();
     size_t arr_size     = value.GetArraySize();
     if (arr_size != 1) {
-        std::cout << "Constant attribute, incompatible size: " << arr_size
-                  << '\n';
+        TF_WARN("Constant attribute, incompatible size: %s", arr_size);
         return false;
     }
 
@@ -790,7 +791,7 @@ _PopulateAttribute(const TfToken& name, const TfToken& role,
 
     } else if (interpolation == HdInterpolationUniform) {
         if (value.GetArraySize() > mesh->GetFaceVertexCounts().size()) {
-            std::cout << "Oversized...\n";
+            TF_WARN("Oversized...");
             return;
         }
 
@@ -899,8 +900,8 @@ _PopulateAttribute(const TfToken& name, const TfToken& role,
             _PopulateAttribte_Constant<GfVec4i, ccl::float4>(value, attr);
         }
     } else {
-        std::cout << "HdCycles WARNING: Interpolation unsupported: "
-                  << interpolation << '\n';
+        TF_WARN("HdCycles WARNING: Interpolation unsupported: %s",
+                interpolation);
     }
 }
 


### PR DESCRIPTION
All cout's of HdCycles have been removed. 

Sidenote: Houdini/Solaris doesnt seem to output TF_STATUS or TF_WARN to the Houdini console. Is there an env var for that? They mention that you can set `TF_DEBUG=PLUG_*` but don't think that works in this case. When run through usdview, the warnings and status' do get written to stdout.


Except for: 

https://github.com/tangent-opensource/hdcycles/blob/improvement/remove_couts/plugin/hdCycles/renderParam.cpp#L148

and

https://github.com/tangent-opensource/hdcycles/blob/improvement/remove_couts/plugin/hdCycles/renderParam.cpp#L165

We do actually want these going into the stdout stream for Deadline to pickup on render progress and logging. @bareya if you have any thoughts, happy to change this.

