### PR TITLE
Feature/volume motion blur

### DIFF
--- a/plugin/hdCycles/camera.cpp
+++ b/plugin/hdCycles/camera.cpp
@@ -71,10 +71,10 @@ EvalCameraParam(T* value, const TfToken& paramName,
 
 #ifdef USE_USD_CYCLES_SCHEMA
 
-std::map<TfToken, ccl::Camera::MotionPosition> MOTION_POSITION_CONVERSION = {
-    { usdCyclesTokens->start, ccl::Camera::MOTION_POSITION_START },
-    { usdCyclesTokens->center, ccl::Camera::MOTION_POSITION_CENTER },
-    { usdCyclesTokens->end, ccl::Camera::MOTION_POSITION_END },
+std::map<TfToken, ccl::MotionPosition> MOTION_POSITION_CONVERSION = {
+    { usdCyclesTokens->start, ccl::MOTION_POSITION_START },
+    { usdCyclesTokens->center, ccl::MOTION_POSITION_CENTER },
+    { usdCyclesTokens->end, ccl::MOTION_POSITION_END },
 };
 
 std::map<TfToken, ccl::Camera::RollingShutterType> ROLLING_SHUTTER_TYPE_CONVERSION
@@ -115,7 +115,8 @@ HdCyclesCamera::HdCyclesCamera(SdfPath const& id,
     , m_needsUpdate(false)
     , m_shutterTime(1.0f)
     , m_rollingShutterTime(0.1f)
-    , m_motionPosition(ccl::Camera::MOTION_POSITION_CENTER)
+    , m_fps(24.0)
+    , m_motionPosition(ccl::MOTION_POSITION_CENTER)
     , m_rollingShutterType(ccl::Camera::ROLLING_SHUTTER_NONE)
     , m_panoramaType(ccl::PANORAMA_EQUIRECTANGULAR)
     , m_stereoEye(ccl::Camera::STEREO_NONE)
@@ -484,16 +485,17 @@ HdCyclesCamera::ApplyCameraSettings(ccl::Camera* a_camera)
     a_camera->nearclip = m_clippingRange.GetMin();
     a_camera->farclip  = m_clippingRange.GetMax();
 
+    a_camera->fps = m_fps;
     a_camera->shuttertime = m_shutterTime;
     a_camera->motion_position
-        = ccl::Camera::MotionPosition::MOTION_POSITION_CENTER;
+        = ccl::MotionPosition::MOTION_POSITION_CENTER;
 
     a_camera->rolling_shutter_duration = m_rollingShutterTime;
 
     a_camera->rolling_shutter_type
         = (ccl::Camera::RollingShutterType)m_rollingShutterType;
     a_camera->panorama_type   = (ccl::PanoramaType)m_panoramaType;
-    a_camera->motion_position = (ccl::Camera::MotionPosition)m_motionPosition;
+    a_camera->motion_position = (ccl::MotionPosition)m_motionPosition;
     a_camera->stereo_eye      = (ccl::Camera::StereoEye)m_stereoEye;
 
     if (m_projectionType == UsdGeomTokens->orthographic) {

--- a/plugin/hdCycles/camera.h
+++ b/plugin/hdCycles/camera.h
@@ -239,6 +239,7 @@ private:
     bool m_useDof;
 
     bool m_useMotionBlur;
+    float m_fps;
 
     HdTimeSampleArray<GfMatrix4d, HD_CYCLES_MOTION_STEPS> m_transformSamples;
 

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -58,7 +58,7 @@ public:
 #endif
 
 
-/// Utility class for translating Hydra Openvdb Asset to Arnold Volume.
+/// Utility class for translating Hydra Openvdb Asset to Cycles Volume.
 class HdCyclesOpenvdbAsset : public HdField {
 public:
     /// Constructor for HdCyclesOpenvdbAsset
@@ -68,15 +68,15 @@ public:
     HDCYCLES_API
     HdCyclesOpenvdbAsset(HdCyclesRenderDelegate* delegate, const SdfPath& id);
 
-    /// Syncing the Hydra Openvdb Asset to the Arnold Volume.
+    /// Syncing the Hydra Openvdb Asset to the Cycles Volume.
     ///
     /// The functions main purpose is to dirty every Volume primitive's
     /// topology, so the grid definitions on the volume can be rebuilt, since
     /// changing the the grid name on the openvdb asset doesn't dirty the
-    /// volume primitive, which holds the arnold volume shape.
+    /// volume primitive, which holds the cycles volume shape.
     ///
     /// @param sceneDelegate Pointer to the Hydra Scene Delegate.
-    /// @param renderParam Pointer to a HdArnoldRenderParam instance.
+    /// @param renderParam Pointer to a HdCyclesRenderParam instance.
     /// @param dirtyBits Dirty Bits to sync.
     HDCYCLES_API
     void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
@@ -88,7 +88,7 @@ public:
     HDCYCLES_API
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
-    /// Tracks a HdArnoldVolume primitive.
+    /// Tracks a HdCyclesVolume primitive.
     ///
     /// Hydra separates the volume definitions from the grids each volume
     /// requires, so we need to make sure each grid definition, which can be

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -47,6 +47,7 @@
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/hd/basisCurves.h>
 #include <pxr/imaging/hd/mesh.h>
+#include <pxr/imaging/hd/volume.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/timeSampleArray.h>
 #include <pxr/pxr.h>
@@ -600,6 +601,30 @@ _HdCyclesGetCameraParam(HdSceneDelegate* a_scene, SdfPath a_id, TfToken a_token,
 {
     VtValue v = a_scene->GetCameraParamValue(a_id, a_token);
     return _HdCyclesGetVtValue<T>(v, a_default);
+}
+
+// Get Volume param
+
+template<typename T>
+T
+_HdCyclesGetVolumeParam(const HdPrimvarDescriptor& a_pvd,
+                      HdDirtyBits* a_dirtyBits, const SdfPath& a_id,
+                      HdVolume* a_volume, HdSceneDelegate* a_scene, TfToken a_token,
+                      T a_default)
+{
+    // TODO: Optimize this
+    // Needed because our current schema stores tokens with primvars: prefix
+    // however the HdPrimvarDescriptor omits this.
+    // Solution could be to remove from usdCycles schema and add in all settings
+    // providers (houdini_cycles, blender exporter)
+    if ("primvars:" + a_pvd.name.GetString() == a_token.GetString()) {
+        if (HdChangeTracker::IsPrimvarDirty(*a_dirtyBits, a_id, a_token)) {
+            VtValue v;
+            v = a_volume->GetPrimvar(a_scene, a_token);
+            return _HdCyclesGetVtValue<T>(v, a_default);
+        }
+    }
+    return a_default;
 }
 
 /* ========= MikkTSpace ========= */

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -313,7 +313,6 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
     if (update_volumes) {
         
         m_cyclesVolume->use_motion_blur = m_useMotionBlur;
-        m_cyclesObject->up_axis = param->GetUpAxis();
         
         bool rebuild = (old_voxel_slots
                         != get_voxel_image_slots(m_cyclesVolume));

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -111,7 +111,7 @@ HdCyclesVolume::_CreateObject()
     ccl::Object* object = new ccl::Object();
 
     object->visibility = ccl::PATH_RAY_ALL_VISIBILITY;
-
+    object->velocity_scale = 1.0f;
     return object;
 }
 
@@ -196,7 +196,6 @@ HdCyclesVolume::_PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate,
                                            : m_cyclesVolume->attributes.add(
                                                name, ccl::TypeDesc::TypeFloat,
                                                ccl::ATTR_ELEMENT_VOXEL);
-
                 ccl::ImageLoader* loader
                     = new HdCyclesVolumeLoader(filepath.c_str(), name.c_str());
                 ccl::ImageParams params;

--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -49,22 +49,22 @@ class HdSceneDelegate;
 class HdCyclesRenderDelegate;
 
 /**
- * @brief Cycles Basis Curve Rprim mapped to Cycles Basis Curve
+ * @brief USD Volume mapped to Cycles Volume
  * 
  */
 class HdCyclesVolume final : public HdVolume {
 public:
     /**
-     * @brief Construct a new HdCycles Basis Curve object
+     * @brief Construct a new HdCycles Volume object
      * 
-     * @param id Path to the Basis Curve Primitive
-     * @param instancerId If specified the HdInstancer at this id uses this curve
+     * @param id Path to the Volume Primitive
+     * @param instancerId If specified the HdInstancer at this id uses this volume
      * as a prototype
      */
     HdCyclesVolume(SdfPath const& id, SdfPath const& instancerId,
                    HdCyclesRenderDelegate* a_renderDelegate);
     /**
-     * @brief Destroy the HdCycles Basis Curves object
+     * @brief Destroy the HdCycles Volume object
      * 
      */
     virtual ~HdCyclesVolume();
@@ -75,7 +75,7 @@ public:
      * 
      * This must be thread safe.
      * 
-     * @param sceneDelegate The data source for the basis curve
+     * @param sceneDelegate The data source for the volume
      * @param renderParam State
      * @param dirtyBits Which bits of scene data has changed
      */
@@ -86,12 +86,12 @@ public:
      * @brief Inform the scene graph which state needs to be downloaded in
      * the first Sync() call
      * 
-     * @return The initial dirty state this basis curve wants to query
+     * @return The initial dirty state this volume wants to query
      */
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     /**
-     * @return Return true if this light is valid.
+     * @return Return true if this volume is valid.
      */
     bool IsValid() const;
 
@@ -125,12 +125,17 @@ protected:
 
 private:
     /**
-     * @brief Create the cycles curve mesh and object representation
+     * @brief Create the cycles object representation
      * 
-     * @return New allocated pointer to ccl::Mesh
+     * @return New allocated pointer to ccl::Object
      */
     ccl::Object* _CreateObject();
 
+    /**
+     * @brief Create the cycles volume mesh representation
+     * 
+     * @return New allocated pointer to ccl::Mesh
+     */
     ccl::Mesh* _CreateVolume();
 
     /**


### PR DESCRIPTION
#### Summary

Adds support for rendering volumes with deformation motion blur 

#### Change Log 

- Added a new function to *utils.h* to parse usdCyclesSchema API params
- Fixed documentation for HdCyclesVolume and HdCyclesOpenvdbAsset

#### Testing 

- Please build cycles with this branch: [feature/volume-motion-blur](https://github.com/tangent-opensource/cycles/tree/feature/volume-motion-blur)
- If you are testing inside houdini please launch houdini with env var: `$Env:HD_CYCLES_UP_AXIS = "Y"`
- Use the below test files or a custom volume with *vel* field to check volume motion blur. 

[test_files.zip](https://github.com/tangent-opensource/hdcycles/files/5959965/test_files.zip)
