### PR TITLE
Enabling motion blur for geometries with varying topology

### DIFF
--- a/plugin/hdCycles/camera.cpp
+++ b/plugin/hdCycles/camera.cpp
@@ -115,6 +115,7 @@ HdCyclesCamera::HdCyclesCamera(SdfPath const& id,
     , m_needsUpdate(false)
     , m_shutterTime(1.0f)
     , m_rollingShutterTime(0.1f)
+    , m_fps(24.f)
     , m_motionPosition(ccl::Camera::MOTION_POSITION_CENTER)
     , m_rollingShutterType(ccl::Camera::ROLLING_SHUTTER_NONE)
     , m_panoramaType(ccl::PANORAMA_EQUIRECTANGULAR)
@@ -484,6 +485,7 @@ HdCyclesCamera::ApplyCameraSettings(ccl::Camera* a_camera)
     a_camera->nearclip = m_clippingRange.GetMin();
     a_camera->farclip  = m_clippingRange.GetMax();
 
+    a_camera->fps         = m_fps;
     a_camera->shuttertime = m_shutterTime;
     a_camera->motion_position
         = ccl::Camera::MotionPosition::MOTION_POSITION_CENTER;

--- a/plugin/hdCycles/camera.h
+++ b/plugin/hdCycles/camera.h
@@ -230,7 +230,7 @@ private:
     float m_fisheyeLens;
     float m_latMin, m_latMax, m_longMin, m_longMax;
     bool m_useSphericalStereo;
-    
+
     float m_interocularDistance;
     float m_convergenceDistance;
     bool m_usePoleMerge;
@@ -239,6 +239,7 @@ private:
     bool m_useDof;
 
     bool m_useMotionBlur;
+    float m_fps;
 
     HdTimeSampleArray<GfMatrix4d, HD_CYCLES_MOTION_STEPS> m_transformSamples;
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -299,8 +299,6 @@ HdCyclesMesh::_AddVelocities(VtVec3fArray& velocities,
 
         for (size_t i = 0; i < velocities.size(); ++i) {
             V[i] = vec3f_to_float3(velocities[i]);
-            //printf("Adding velocity %.3f %.3f %.3f - %.3f %.3f %.3f\n", V[i].x, V[i].y, V[i].z,
-            //velocities[i][0], velocities[i][1], velocities[i][2]);
         }
     } else {
         TF_WARN("Velocity requries per-vertex interpolation");
@@ -985,9 +983,6 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
         std::vector<int> faceMaterials;
         faceMaterials.resize(m_numMeshFaces);
 
-        // Rebuilding is triggered anyway in the first iteration
-        m_cyclesMesh->need_update_rebuild = topologyIsDirty;
-
         for (auto const& subset : m_geomSubsets) {
             int subsetMaterialIndex = 0;
 
@@ -1277,12 +1272,13 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
         _FinishMesh(scene);
     }
 
-    if (mesh_updated || newMesh) {
+    if (mesh_updated || newMesh || topologyIsDirty) {
         m_cyclesObject->visibility = m_visibilityFlags;
         if (!_sharedData.visible)
             m_cyclesObject->visibility = 0;
 
-        m_cyclesMesh->tag_update(scene, false);
+
+        m_cyclesMesh->tag_update(scene, topologyIsDirty);
         m_cyclesObject->tag_update(scene);
         param->Interrupt();
     }

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -277,16 +277,12 @@ HdCyclesMesh::_AddVelocities(VtVec3fArray& velocities,
                                         ? &m_cyclesMesh->subd_attributes
                                         : &m_cyclesMesh->attributes;
 
-    // Enabling motion blur if velocities are present
-    m_cyclesMesh->use_motion_blur = true;
-    m_cyclesMesh->motion_steps    = 3;
-
     // If motion data has been populated, we only issue a warning for now.
     ccl::Attribute* attr_mP = attributes->find(
         ccl::ATTR_STD_MOTION_VERTEX_POSITION);
 
     if (attr_mP) {
-        TFWARN("Velocities will be ignored since motion positions exist");
+        TF_WARN("Velocities will be ignored since motion positions exist");
         return;
     }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -338,38 +338,6 @@ HdCyclesMesh::_AddAccelerations(VtVec3fArray& accelerations,
     }
 }
 
-/*
-    Adding angular velocities to improve the quality of the motion blur geometry.
-    They will be active only if the velocities are present.
-*/
-void
-HdCyclesMesh::_AddAngularVelocities(VtVec3fArray& w,
-                                    HdInterpolation interpolation)
-{
-    ccl::AttributeSet* attributes = (m_useSubdivision && m_subdivEnabled)
-                                        ? &m_cyclesMesh->subd_attributes
-                                        : &m_cyclesMesh->attributes;
-
-    ccl::Attribute* attr_w = attributes->find(
-        ccl::ATTR_STD_VERTEX_ANGULAR_VELOCITY);
-    if (!attr_w) {
-        attr_w = attributes->add(ccl::ATTR_STD_VERTEX_ANGULAR_VELOCITY);
-    }
-
-    if (interpolation == HdInterpolationVertex) {
-        assert(w.size() == m_cyclesMesh->verts.size());
-
-        ccl::float3* W = attr_w->data_float3();
-
-        for (size_t i = 0; i < w.size(); ++i) {
-            W[i] = vec3f_to_float3(w[i]);
-        }
-    } else {
-        TF_WARN("Angular velocity requires per-vertex interpolation");
-    }
-}
-
-
 void
 HdCyclesMesh::_AddColors(TfToken name, TfToken role, VtValue colors,
                          ccl::Scene* scene, HdInterpolation interpolation)
@@ -1124,19 +1092,6 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                             accels = value.UncheckedGet<VtArray<GfVec3f>>();
 
                             _AddAccelerations(accels, primvarDescsEntry.first);
-                            mesh_updated = true;
-                        }
-                    }
-
-                    // - Angular velocities
-                    // The primvar name is from https://www.sidefx.com/docs/houdini/render/blur.html
-
-                    else if (strcmp(pv.name.GetText(), "w") == 0) {
-                        if (value.IsHolding<VtArray<GfVec3f>>()) {
-                            VtVec3fArray w;
-                            w = value.UncheckedGet<VtArray<GfVec3f>>();
-
-                            _AddAngularVelocities(w, primvarDescsEntry.first);
                             mesh_updated = true;
                         }
                     }

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -141,13 +141,31 @@ protected:
     void _AddNormals(VtVec3fArray& normals, HdInterpolation interpolation);
 
     /**
-     * @brief Add vertex velocities (Not tested)
+     * @brief Add vertex velocities
      * 
      * @param velocities 
      * @param interpolation 
      */
     void _AddVelocities(VtVec3fArray& velocities,
                         HdInterpolation interpolation);
+
+
+    /**
+     * @brief Add vertex accelerations
+     * 
+     * @param accelerations 
+     * @param interpolation 
+     */
+    void _AddAccelerations(VtVec3fArray& accelerations,
+                           HdInterpolation interpolation);
+
+    /**
+     * @brief Add vertex angular accelerations
+     * 
+     * @param angular accelerations 
+     * @param interpolation 
+     */
+    void _AddAngularVelocities(VtVec3fArray& w, HdInterpolation interpolation);
 
     /**
      * @brief Add vertex/primitive colors

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -160,14 +160,6 @@ protected:
                            HdInterpolation interpolation);
 
     /**
-     * @brief Add vertex angular accelerations
-     * 
-     * @param angular accelerations 
-     * @param interpolation 
-     */
-    void _AddAngularVelocities(VtVec3fArray& w, HdInterpolation interpolation);
-
-    /**
      * @brief Add vertex/primitive colors
      * TODO: This handles more than just colors, we should probably refactor
      * 


### PR DESCRIPTION
**Overview**
Enabling motion blur to be computed from velocities and accelerations.

**Changes**
- Triggering rebuild of the BVH for meshes with varying topology to prevent segfaults.
- Adding velocity, acceleration and angular velocity attributes to the Cycles mesh

**Comments**
Added frames per second to camera [as in the volume motion blur PR](https://github.com/tangent-opensource/hdcycles/pull/75), there should not be any conflicts.

See [Cycles PR](https://github.com/tangent-opensource/cycles/pull/7)

Without motion blur
![fluid_no_blur_0](https://user-images.githubusercontent.com/2072636/108902763-850dc000-75ea-11eb-99fa-d1b82e33b4bf.PNG)
With motion blur
![fluid_with_blur](https://user-images.githubusercontent.com/2072636/108902776-87701a00-75ea-11eb-8e29-52b1c052d803.PNG)
