### PR TITLE
Added displacement node to shader definition registry

### DIFF
--- a/plugin/ndrCycles/discovery.cpp
+++ b/plugin/ndrCycles/discovery.cpp
@@ -71,6 +71,7 @@ NdrCyclesDiscoveryPlugin::DiscoverNodes(const Context& context)
     temp_nodes.push_back("scatter_volume");
     temp_nodes.push_back("absorption_volume");
     temp_nodes.push_back("emission");
+    temp_nodes.push_back("displacement");
 
     for (const std::string& n : temp_nodes) {
         std::string cycles_id = std::string("cycles_" + n);


### PR DESCRIPTION
Displacement shaders would fail as their ID was not found in the shader definition registry. This PR simply adds the definition.

Ideally, things should be done automatically through the Cycles API (either once or every time), like it's being done in the [hda shader generator](https://github.com/tangent-opensource/houdini_cycles/blob/main/scripts/cycles_shaders_generator/hda_generator.cpp). To not delay the next build, this will do in the meantime but the same issue could come up for future shaders.