### PR TITLE
Feature/aovs

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1105,6 +1105,7 @@ HdCyclesMesh::_InitializeNewCyclesMesh()
         m_cyclesMesh->use_motion_blur = m_useDeformMotionBlur;
     }
 
+    m_cyclesObject->name = GetId().GetString();
     m_cyclesObject->geometry = m_cyclesMesh;
 
     m_renderDelegate->GetCyclesRenderParam()->AddGeometry(m_cyclesMesh);

--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -369,7 +369,7 @@ HdCyclesRenderDelegate::GetDefaultAovDescriptor(TfToken const& name) const
         colorFormat = HdFormatFloat32Vec4;
     }
 
-    if (name == HdAovTokens->color) {
+    if (name == HdAovTokens->color || name == HdCyclesAovTokens->DiffDir) {
         return HdAovDescriptor(colorFormat, false, VtValue(GfVec4f(0.0f)));
     } else if (name == HdAovTokens->normal) {
         if (use_tiles) {
@@ -379,7 +379,7 @@ HdCyclesRenderDelegate::GetDefaultAovDescriptor(TfToken const& name) const
     } else if (name == HdAovTokens->depth) {
         return HdAovDescriptor(HdFormatFloat32, false, VtValue(1.0f));
     } else if (name == HdAovTokens->primId || name == HdAovTokens->instanceId
-               || name == HdAovTokens->elementId) {
+               || name == HdAovTokens->elementId || name == HdCyclesAovTokens->IndexMA) {
         return HdAovDescriptor(HdFormatInt32, false, VtValue(-1));
     } else if (name == HdCyclesAovTokens->DiffDir) {
         return HdAovDescriptor(colorFormat, false, VtValue(GfVec4f(0.0f)));

--- a/plugin/hdCycles/renderDelegate.h
+++ b/plugin/hdCycles/renderDelegate.h
@@ -90,8 +90,11 @@ TF_DECLARE_PUBLIC_TOKENS(HdCyclesIntegratorTokens,
     HDCYCLES_INTEGRATOR_TOKENS
 );
 
+const TfToken aovc;
+const TfToken aovv;
 
 #define HDCYCLES_AOV_TOKENS \
+    (UV)                    \
     (Vector)                \
     (IndexMA)               \
                             \
@@ -100,10 +103,27 @@ TF_DECLARE_PUBLIC_TOKENS(HdCyclesIntegratorTokens,
     (TransDir)              \
     (VolumeDir)             \
                             \
+    (DiffInd)               \
+    (GlossInd)              \
+    (TransInd)              \
+    (VolumeInd)             \
+                            \
+    (DiffCol)               \
+    (GlossCol)              \
+    (TransCol)              \
+    (VolumeCol)             \
+                            \
     (Emit)                  \
     (Env)                   \
     (AO)                    \
-    (Shadow)
+    (Shadow)                \
+                            \
+    (CryptoObject)          \
+    (CryptoMaterial)        \
+    (CryptoAsset)           \
+                            \
+    ((AOVC, "aovc:"))       \
+    ((AOVV, "aovv:"))
 
 TF_DECLARE_PUBLIC_TOKENS(HdCyclesAovTokens, 
     HDCYCLES_API, 

--- a/plugin/hdCycles/renderDelegate.h
+++ b/plugin/hdCycles/renderDelegate.h
@@ -90,9 +90,6 @@ TF_DECLARE_PUBLIC_TOKENS(HdCyclesIntegratorTokens,
     HDCYCLES_INTEGRATOR_TOKENS
 );
 
-const TfToken aovc;
-const TfToken aovv;
-
 #define HDCYCLES_AOV_TOKENS \
     (UV)                    \
     (Vector)                \
@@ -122,14 +119,14 @@ const TfToken aovv;
     (CryptoMaterial)        \
     (CryptoAsset)           \
                             \
-    ((AOVC, "aovc:"))       \
-    ((AOVV, "aovv:"))       \
+    (AOVC)                  \
+    (AOVV)                  \
                             \
     (P)                     \
     (Pref)                  \
     (Ngn)                   \
-    (cpuTime)               \
-    (sampleCount)
+    (RenderTime)            \
+    (SampleCount)
 
 TF_DECLARE_PUBLIC_TOKENS(HdCyclesAovTokens, 
     HDCYCLES_API, 

--- a/plugin/hdCycles/renderDelegate.h
+++ b/plugin/hdCycles/renderDelegate.h
@@ -123,7 +123,13 @@ const TfToken aovv;
     (CryptoAsset)           \
                             \
     ((AOVC, "aovc:"))       \
-    ((AOVV, "aovv:"))
+    ((AOVV, "aovv:"))       \
+                            \
+    (P)                     \
+    (Pref)                  \
+    (Ngn)                   \
+    (cpuTime)               \
+    (sampleCount)
 
 TF_DECLARE_PUBLIC_TOKENS(HdCyclesAovTokens, 
     HDCYCLES_API, 

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -441,13 +441,16 @@ private:
     std::mutex m_shaders_mutex;
 
     HdRenderPassAovBindingVector m_aovs;
+    std::string m_displayAovName;
 
 public:
-    void SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
+    void SetDisplayAov(HdRenderPassAovBinding const& aov);
+    const std::string &GetDisplayAovName() const
     {
-        m_aovs = a_aovs;
+        return m_displayAovName;
     }
 
+    void SetAovBindings(HdRenderPassAovBindingVector const& a_aovs);
     HdRenderPassAovBindingVector const& GetAovBindings() const
     {
         return m_aovs;

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -441,17 +441,45 @@ private:
     std::mutex m_shaders_mutex;
 
     HdRenderPassAovBindingVector m_aovs;
-    std::string m_displayAovName;
+    TfToken m_displayAovToken;
 
 public:
-    void SetDisplayAov(HdRenderPassAovBinding const& aov);
-    const std::string &GetDisplayAovName() const
+
+    /**
+     * @brief Set the default display AOV
+     * 
+     * @param a_aov Set a HdRenderPassAovBinding from HdCyclesRenderPass
+     * 
+     * TODO: Currently there is no upstream from Houdini way to apply a default
+     * AOV to view, so it'll just default to color or the first one found. A
+     * possible workaround is to just make Cycles render all AOVs at once in
+     * display mode.
+     */
+    void SetDisplayAov(HdRenderPassAovBinding const &a_aov);
+
+    /**
+     * @brief Get the default display AOV token
+     * 
+     * @return TfToken of the default AOV diplay
+     */
+    const TfToken &GetDisplayAovToken() const
     {
-        return m_displayAovName;
+        return m_displayAovToken;
     }
 
-    void SetAovBindings(HdRenderPassAovBindingVector const& a_aovs);
-    HdRenderPassAovBindingVector const& GetAovBindings() const
+    /**
+     * @brief Set the AOV bindings
+     * 
+     * @param a_aovs Set a HdRenderPassAovBindingVector from HdCyclesRenderPass
+     */
+    void SetAovBindings(HdRenderPassAovBindingVector const &a_aovs);
+
+    /**
+     * @brief Get the AOV bindings
+     * 
+     * @return HdRenderPassAovBindingVector
+     */
+    HdRenderPassAovBindingVector const &GetAovBindings() const
     {
         return m_aovs;
     }

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -61,8 +61,12 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
 
     HdRenderPassAovBindingVector aovBindings = renderPassState->GetAovBindings();
 
-    if (renderParam->GetAovBindings() != aovBindings)
+    if (renderParam->GetAovBindings() != aovBindings) {
         renderParam->SetAovBindings(aovBindings);
+        if(!aovBindings.empty()) {
+            renderParam->SetDisplayAov(aovBindings[0]);
+        }
+    }
 
     const auto vp = renderPassState->GetViewport();
 
@@ -188,7 +192,7 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
             // when changing render settings. This causes the current blit to
             // fail (Probably can be fixed with proper render thread management)
             if (!rb->WasUpdated()) {
-                if (aov.aovName == HdAovTokens->color) {
+                if (aov.aovName == renderParam->GetDisplayAovName()) {
                     rb->Blit(colorFormat, w, h, 0, w,
                              reinterpret_cast<uint8_t*>(hpixels));
                 }

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -192,7 +192,7 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
             // when changing render settings. This causes the current blit to
             // fail (Probably can be fixed with proper render thread management)
             if (!rb->WasUpdated()) {
-                if (aov.aovName == renderParam->GetDisplayAovName()) {
+                if (aov.aovName == renderParam->GetDisplayAovToken()) {
                     rb->Blit(colorFormat, w, h, 0, w,
                              reinterpret_cast<uint8_t*>(hpixels));
                 }


### PR DESCRIPTION
Refining some much-needed AOV support in HdCycles based on the branch @skwerner started. Currently the viewport is still locked to color as this is how it works inside of Blender and then you toggle which AOV to view. Houdini works differently, it wants all AOVs up-front and then you toggle which to view, and unfortunately there is no way to pass this information to Cycles. This will need a patch to Cycles to work how Houdini expects most likely.

There's also some strange bug where if you set the default display to color/Combined (beauty) and you also have DiffDir/direct-diffuse, it will always default to use DiffDir for the display, perhaps this is a Cycles bug? All other AOVs will not override the default beauty render as default...

Having said all of the above, if we render offline to an .exr or to MPlay with the HD_CYCLES_USE_TILED_RENDERING=1 environment variable, it will render correctly to what you expect, as long as your RenderVars/RenderProducts are all correctly set in the USD file.

For those of you playing at home, to make sure this env-var is working with MPlay, set the Pre-render script on the USD Render ROP node to Python and use:
`import os;os.environ['HD_CYCLES_USE_TILED_RENDERING'] = '1';`

And the currently searched for default AOVs are listed here, if you were to make your own RenderVars:
```
Blender Convention | USD Convention (RenderVar name)
Combined             color
Depth                cameraDepth
Normal               normal
IndexOB              primId
IndexMA              IndexMA
Mist                 depth
Emission             Emit
Shadow               Shadow
UV                   UV
Vector               Vector
DiffDir              DiffDir
DiffInd              DiffInd
DiffCol              DiffCol
GlossDir             GlossDir
GlossInd             GlossInd
GlossCol             GlossCol
TransDir             TransDir
TransInd             TransInd
TransCol             TransCol
VolumeDir            VolumeDir
VolumeInd            VolumeInd
```
I don't think we need to follow exact naming-convention that Blender uses here though, we could go cameCase with more descriptive names.

There is also the start of supporting Cryptomatte in this PR, however this will need to be refined still as Hydra's HDRenderBuffer can only know of 1 buffer at a time, while Cryptomattes need to have multiple ones based on depth/rank. Houdini's Karma gets around this by using a different base-class XUSD_HydraRenderBuffer here which supplies an index to an array of render-buffers:

https://github.com/sideeffects/HoudiniUsdBridge/blob/master/src/houdini/lib/H_USD/HUSD/XUSD_HydraRenderBuffer.h

So that husk will know how to write these to disk properly. If we go down this route we will need to hide it behind a pre-processor define so that there is no hard-dependency onto Houdini (it just means cryptomattes will only work in Houdini/Husk).

There's also the startings of custom AOVs, with the syntax:
```
"aovc:myCustomColor"
"aovv:myCustomValue"
```
With the AovOutput shader name being `"myCustomColor"`/`"myCustomValue"` to get detected and written to the AOV. However the AovOutput shader node will need some work so that it is successfully detected and added to the authored materials to really test that this works, for now.
