### PR TITLE
PopulateNormals warnings

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -535,7 +535,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
     if (!GetPrimvarInterpolation(interpolation)) {
         // TODO: Should we autogenerate normals or let Cycles generate them?
         // Let's shoot a warning for now
-        TF_WARN("Failed to find interpolation for normals for: %s", id.GetText());
+        //TF_WARN("Failed to find interpolation for normals for: %s", id.GetText());
         return;
     }
     assert(interpolation >= 0 && interpolation < HdInterpolationCount);


### PR DESCRIPTION
The line in question was being printed even if the geometry had no normals. I tried to limit the print by checking if the original dirty bits included the normals (without the extra propagation), but no help.

Are all the initial bits set to dirty even if the primitive doesn't have that attribute?