### PR TITLE
First step with TF_DEBUG codes

### DIFF
--- a/plugin/hdCycles/CMakeLists.txt
+++ b/plugin/hdCycles/CMakeLists.txt
@@ -112,6 +112,7 @@ pxr_plugin(${PXR_PACKAGE}
 
   PUBLIC_HEADERS
     api.h
+    debug_codes.h
 
   RESOURCE_FILES
     plugInfo.json

--- a/plugin/hdCycles/debug_codes.h
+++ b/plugin/hdCycles/debug_codes.h
@@ -16,7 +16,9 @@
 //  arising from the use of this software, whether in contract, tort or otherwise.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-#pragma once
+
+#ifndef HD_CYCLES_DEBUG_CODES_H
+#define HD_CYCLES_DEBUG_CODES_H
 
 #include <pxr/pxr.h>
 
@@ -31,3 +33,5 @@ TF_DEBUG_CODES(
 // clang-format on
 
 PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HD_CYCLES_DEBUG_CODES_H

--- a/plugin/hdCycles/debug_codes.h
+++ b/plugin/hdCycles/debug_codes.h
@@ -1,0 +1,33 @@
+//  Copyright 2021 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#pragma once
+
+#include <pxr/pxr.h>
+
+#include <pxr/base/tf/debug.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// clang-format off
+TF_DEBUG_CODES(
+	HDCYCLES_MESH
+)
+// clang-format on
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -25,6 +25,7 @@
 #include "renderDelegate.h"
 #include "renderParam.h"
 #include "utils.h"
+#include "debug_codes.h"
 
 #include <pxr/imaging/hd/extComputationUtils.h>
 
@@ -533,9 +534,9 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
 
     HdInterpolation interpolation = HdInterpolationCount;
     if (!GetPrimvarInterpolation(interpolation)) {
-        // TODO: Should we autogenerate normals or let Cycles generate them?
-        // Let's shoot a warning for now
-        TF_WARN("Failed to find interpolation for normals for: %s", id.GetText());
+        m_cyclesMesh->add_vertex_normals();
+        TF_INFO(HDCYCLES_MESH)
+            .Msg("Generating smooth normals for: %s", id.GetText());
         return;
     }
     assert(interpolation >= 0 && interpolation < HdInterpolationCount);


### PR DESCRIPTION
Issuing a possibly useful warning through its own debug code rather than a generic warning/error. This can be controlled through the environment variable `TF_DEBUG=HDCYCLES_MESH` or `TF_DEBUG=HDCYCLES_*` in the future.

In the future non fatal application-level messages should go through our custom codes and ideally the USD/Hydra warnings should disappear through better use of the API.