### PR TITLE
Uncomment the code to compute the deform blur steps

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -722,11 +722,9 @@ HdCyclesMesh::_PopulateMotion(HdSceneDelegate* sceneDelegate, const SdfPath& id)
     if (attr_mP)
         attributes->remove(attr_mP);
 
-    if (!attr_mP) {
-        attr_mP = attributes->add(ccl::ATTR_STD_MOTION_VERTEX_POSITION);
-    }
-
+    attr_mP = attributes->add(ccl::ATTR_STD_MOTION_VERTEX_POSITION);
     ccl::float3* mP = attr_mP->data_float3();
+    
     for (size_t i = 0; i < numSamples; ++i) {
         if (times[i] == 0.0f) // todo: more flexible check?
             continue;
@@ -1289,7 +1287,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
     }
 
     if (m_useMotionBlur && m_useDeformMotionBlur) {
-        //_PopulateMotion(sceneDelegate, id);
+        _PopulateMotion(sceneDelegate, id);
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyNormals) {


### PR DESCRIPTION
`_PopulateMotion` was left commented in one of the previous merges, this PR uncomments it and fixes a bug where the motion points attribute was not being added.