### PR TITLE
Lock cycles session display buffer

### DIFF
--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1400,7 +1400,7 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
     if (!m_useTiledRendering)
         return;
 
-    std::lock_guard<std::mutex> lock(m_cyclesScene->mutex);
+    ccl::thread_scoped_lock session_lock(m_cyclesScene->mutex);
 
     const int w = rtile.w;
     const int h = rtile.h;

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1402,9 +1402,6 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
 
     std::lock_guard<std::mutex> lock(m_cyclesScene->mutex);
 
-    const int x = rtile.x;
-    const int y = rtile.y;
-    
     const int w = rtile.w;
     const int h = rtile.h;
 

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1332,6 +1332,8 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
     if (!m_useTiledRendering)
         return;
 
+    std::lock_guard<std::mutex> lock(m_cyclesScene->mutex);
+
     const int x = rtile.x;
     const int y = rtile.y;
     const int w = rtile.w;

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -151,6 +151,7 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
     if (!renderParam->GetCyclesScene())
         return;
 
+    renderParam->GetCyclesSession()->acquire_display();
     ccl::DisplayBuffer* display = renderParam->GetCyclesSession()->display;
 
     if (!display)
@@ -164,14 +165,18 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
               ? (unsigned char*)display->rgba_half.host_pointer
               : (unsigned char*)display->rgba_byte.host_pointer;
 
-    if (!hpixels)
+    if (!hpixels) {
+        renderParam->GetCyclesSession()->release_display();
         return;
+    }
 
     int w = display->draw_width;
     int h = display->draw_height;
 
-    if (w == 0 || h == 0)
+    if (w == 0 || h == 0) {
+        renderParam->GetCyclesSession()->release_display();
         return;
+    }
 
     // Blit
     if (!aovBindings.empty()) {
@@ -197,6 +202,8 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
             }
         }
     }
+
+    renderParam->GetCyclesSession()->release_display();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -153,12 +153,12 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
     if (!renderParam->GetCyclesScene())
         return;
 
-    renderParam->GetCyclesSession()->acquire_display();
     ccl::DisplayBuffer* display = renderParam->GetCyclesSession()->display;
 
     if (!display)
         return;
 
+    renderParam->GetCyclesSession()->acquire_display();
     HdFormat colorFormat = display->half_float ? HdFormatFloat16Vec4
                                                : HdFormatUNorm8Vec4;
 


### PR DESCRIPTION
Locking the display when reading from its pixel buffer. This caused crashes when the Houdini viewport was being resized as the display buffer was being deallocated during reading #102 

This [Cycles PR ](https://github.com/tangent-opensource/cycles/pull/20)is required.