### PR TITLE
Deferring adding curve to scene to when geometry is available

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -74,14 +74,6 @@ HdCyclesBasisCurves::HdCyclesBasisCurves(
     config.enable_motion_blur.eval(m_useMotionBlur, true);
 
     m_cyclesObject = _CreateObject();
-    //m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
-
-    // Attaching a temporary mesh to the object since Cycles expects
-    // objects to have a geometry.
-    // This will be overwritten during sync if successful, but will
-    // prevent a crash if unsuccessful
-    //m_cyclesGeometry = new ccl::Mesh;
-    //m_cyclesObject->geometry = m_cyclesGeometry;
 }
 
 HdCyclesBasisCurves::~HdCyclesBasisCurves()

--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -74,7 +74,14 @@ HdCyclesBasisCurves::HdCyclesBasisCurves(
     config.enable_motion_blur.eval(m_useMotionBlur, true);
 
     m_cyclesObject = _CreateObject();
-    m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
+    //m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
+
+    // Attaching a temporary mesh to the object since Cycles expects
+    // objects to have a geometry.
+    // This will be overwritten during sync if successful, but will
+    // prevent a crash if unsuccessful
+    //m_cyclesGeometry = new ccl::Mesh;
+    //m_cyclesObject->geometry = m_cyclesGeometry;
 }
 
 HdCyclesBasisCurves::~HdCyclesBasisCurves()
@@ -444,6 +451,8 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     HdCyclesRenderParam* param = (HdCyclesRenderParam*)renderParam;
 
     ccl::Scene* scene = param->GetCyclesScene();
+    //std::lock_guard<std::mutex>(scene->mutex);
+
 
     HdCyclesPDPIMap pdpi;
     bool generate_new_curve = false;
@@ -612,6 +621,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
         _PopulateCurveMesh(param);
 
         if (m_cyclesGeometry) {
+            m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
             m_cyclesObject->geometry = m_cyclesGeometry;
 
             m_cyclesGeometry->compute_bounds();

--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -451,8 +451,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     HdCyclesRenderParam* param = (HdCyclesRenderParam*)renderParam;
 
     ccl::Scene* scene = param->GetCyclesScene();
-    //std::lock_guard<std::mutex>(scene->mutex);
-
+    ccl::thread_scoped_lock scene_lock(scene->mutex);
 
     HdCyclesPDPIMap pdpi;
     bool generate_new_curve = false;
@@ -621,7 +620,10 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
         _PopulateCurveMesh(param);
 
         if (m_cyclesGeometry) {
+            scene_lock.unlock();
             m_renderDelegate->GetCyclesRenderParam()->AddObject(m_cyclesObject);
+            scene_lock.lock();
+
             m_cyclesObject->geometry = m_cyclesGeometry;
 
             m_cyclesGeometry->compute_bounds();


### PR DESCRIPTION
Adding the curve object to the scene only when geometry is available, this prevents crashes as described in #101.

I also added a lock to the scene to be consistent with other geometries.

Internal ticket #5628