### PR TITLE
Add NanoVDB package to HdCycles cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,14 @@ if(${OpenVDB_FOUND})
   message("[HDCYCLES] Configured with OpenVDB")
 endif()
 
+find_package(NanoVDB)
+if(${NanoVDB_FOUND})
+  set(WITH_NANOVDB ON)
+  add_definitions(-DWITH_NANOVDB)
+  message("[HDCYCLES] Configured with NanoVDB")
+endif()
+
+
 find_package(Embree)
 if(${Embree_FOUND})
   set(WITH_EMBREE ON)

--- a/cmake/modules/FindNanoVDB.cmake
+++ b/cmake/modules/FindNanoVDB.cmake
@@ -1,0 +1,49 @@
+# - Find NanoVDB library
+# Find the native NanoVDB includes and library
+# This module defines
+#  NANOVDB_INCLUDE_DIRS, where to find nanovdb.h, Set when
+#                         NANOVDB_INCLUDE_DIR is found.
+#  NANOVDB_ROOT, The base directory to search for NanoVDB.
+#                     This can also be an environment variable.
+#  NANOVDB_FOUND, If false, do not try to use NanoVDB.
+
+#=============================================================================
+# Copyright 2020 Blender Foundation.
+#
+# Distributed under the OSI-approved BSD 3-Clause License,
+# see accompanying file BSD-3-Clause-license.txt for details.
+#=============================================================================
+
+# If NANOVDB_ROOT was defined in the environment, use it.
+IF(NOT NANOVDB_ROOT AND NOT $ENV{NANOVDB_ROOT} STREQUAL "")
+  SET(NANOVDB_ROOT $ENV{NANOVDB_ROOT})
+ENDIF()
+
+SET(_nanovdb_SEARCH_DIRS
+  ${NANOVDB_ROOT}
+)
+
+FIND_PATH(NANOVDB_INCLUDE_DIR
+  NAMES
+    nanovdb/NanoVDB.h
+  HINTS
+    ${_nanovdb_SEARCH_DIRS}
+  PATH_SUFFIXES
+    include
+)
+
+# handle the QUIETLY and REQUIRED arguments and set NANOVDB_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(NanoVDB DEFAULT_MSG
+    NANOVDB_INCLUDE_DIR)
+
+IF(NANOVDB_FOUND)
+  SET(NANOVDB_INCLUDE_DIRS ${NANOVDB_INCLUDE_DIR})
+ENDIF(NANOVDB_FOUND)
+
+MARK_AS_ADVANCED(
+  NANOVDB_INCLUDE_DIR
+)
+
+UNSET(_nanovdb_SEARCH_DIRS)

--- a/plugin/hdCycles/CMakeLists.txt
+++ b/plugin/hdCycles/CMakeLists.txt
@@ -33,6 +33,10 @@ if(WITH_OPENVDB)
     link_libraries(${OPENVDB_LIBRARY})
 endif()
 
+if(WITH_NANOVDB)
+    include_directories(SYSTEM ${NANOVDB_INCLUDE_DIR})
+endif()
+
 if(WITH_EMBREE)
     include_directories(SYSTEM ${EMBREE_INCLUDE_DIRS})
     link_libraries(${EMBREE_LIBRARIES})


### PR DESCRIPTION
This PR adds nanovdb package (and "WITH_NANOVDB" preprocessor definition) to hdcycles build system so cycles openVDBLoader nanogrid is initialized correctly. Fixes internal tickets PT-734 and PT-836