### PR TITLE
Fix hdCycles crash on updating volumes PT-835

### DIFF
--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -41,28 +41,25 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdCyclesVolumeLoader : public ccl::VDBImageLoader {
 public:
     HdCyclesVolumeLoader(const char* filepath, const char* grid_name)
-        : ccl::VDBImageLoader(grid_name), m_file_path(filepath)
+        : ccl::VDBImageLoader(grid_name)
+        , m_file_path(filepath)
     {
-        openvdb::io::File file(filepath);
-
-        try {
-            file.setCopyMaxBytes(0);
-            file.open();
-            this->grid = file.readGrid(grid_name);
-        } catch (const openvdb::IoError& e) {
-            std::cout << "LOAD ERROR\n";
-        }
+        UpdateGrid();
     }
 
-    void UpdateGrid(){
-        openvdb::io::File file(m_file_path);
+    void UpdateGrid()
+    {
+        if(TF_VERIFY(!m_file_path.empty()))
+        {
+            openvdb::io::File file(m_file_path);
 
-        try {
-            file.setCopyMaxBytes(0);
-            file.open();
-            this->grid = file.readGrid(grid_name);
-        } catch (const openvdb::IoError& e) {
-            std::cout << "LOAD ERROR\n";
+            try {
+                file.setCopyMaxBytes(0);
+                file.open();
+                this->grid = file.readGrid(grid_name);
+            } catch (const openvdb::IoError& e) {
+                TF_RUNTIME_ERROR("Unable to load grid %s from file %s", grid_name, m_file_path);
+            }
         }
     }
 

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -41,9 +41,22 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdCyclesVolumeLoader : public ccl::VDBImageLoader {
 public:
     HdCyclesVolumeLoader(const char* filepath, const char* grid_name)
-        : ccl::VDBImageLoader(grid_name)
+        : ccl::VDBImageLoader(grid_name), m_file_path(filepath)
     {
         openvdb::io::File file(filepath);
+
+        try {
+            file.setCopyMaxBytes(0);
+            file.open();
+            this->grid = file.readGrid(grid_name);
+            this->nanogrid.buffer().init(1);
+        } catch (const openvdb::IoError& e) {
+            std::cout << "LOAD ERROR\n";
+        }
+    }
+
+    void UpdateGrid(){
+        openvdb::io::File file(m_file_path);
 
         try {
             file.setCopyMaxBytes(0);
@@ -53,6 +66,9 @@ public:
             std::cout << "LOAD ERROR\n";
         }
     }
+
+private:
+    std::string m_file_path;
 };
 #endif
 

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -49,7 +49,6 @@ public:
             file.setCopyMaxBytes(0);
             file.open();
             this->grid = file.readGrid(grid_name);
-            this->nanogrid.buffer().init(1);
         } catch (const openvdb::IoError& e) {
             std::cout << "LOAD ERROR\n";
         }

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -51,9 +51,8 @@ public:
     {
         if(TF_VERIFY(!m_file_path.empty()))
         {
-            openvdb::io::File file(m_file_path);
-
             try {
+                openvdb::io::File file(m_file_path);
                 file.setCopyMaxBytes(0);
                 file.open();
 
@@ -64,6 +63,8 @@ public:
                 this->grid = file.readGrid(grid_name);
             } catch (const openvdb::IoError& e) {
                 TF_RUNTIME_ERROR("Unable to load grid %s from file %s", grid_name, m_file_path);
+            } catch(const std::exception& e) {
+                TF_RUNTIME_ERROR("Error updating grid: %s", e.what());
             }
         }else{
             TF_WARN("Volume file path is empty!");

--- a/plugin/hdCycles/openvdb_asset.h
+++ b/plugin/hdCycles/openvdb_asset.h
@@ -56,11 +56,25 @@ public:
             try {
                 file.setCopyMaxBytes(0);
                 file.open();
+
+                if(grid){
+                    grid.reset();
+                }
+
                 this->grid = file.readGrid(grid_name);
             } catch (const openvdb::IoError& e) {
                 TF_RUNTIME_ERROR("Unable to load grid %s from file %s", grid_name, m_file_path);
             }
+        }else{
+            TF_WARN("Volume file path is empty!");
         }
+    }
+
+    void cleanup() override 
+    {
+        #ifdef WITH_NANOVDB
+        nanogrid.reset();
+        #endif
     }
 
 private:

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -213,6 +213,23 @@ HdCyclesVolume::_PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate,
 #endif
 }
 
+void HdCyclesVolume::_UpdateGrids(){
+#ifdef WITH_OPENVDB
+    if(m_cyclesVolume){
+        for (ccl::Attribute& attr : m_cyclesVolume->attributes.attributes) {
+            if (attr.element == ccl::ATTR_ELEMENT_VOXEL) {
+                ccl::ImageHandle &handle = attr.data_voxel();
+                auto* loader = static_cast<HdCyclesVolumeLoader*>(handle.vdb_loader());
+
+                if(loader){
+                    loader->UpdateGrid();
+                }
+            }
+        }
+    }
+#endif  
+}
+
 /* If the voxel attributes change, we need to rebuild the bounding mesh. */
 static ccl::vector<int>
 get_voxel_image_slots(ccl::Mesh* mesh)
@@ -310,7 +327,7 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
 #endif
 
     if (update_volumes) {
-        
+        _UpdateGrids();
         m_cyclesVolume->use_motion_blur = m_useMotionBlur;
         
         bool rebuild = (old_voxel_slots

--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -144,6 +144,11 @@ private:
     void _PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate,
                          ccl::Scene* scene);
 
+    /**
+     * @brief Update the OpenVDB loader grid for mesh builder  
+     */
+    void _UpdateGrids();
+
     ccl::Object* m_cyclesObject;
 
     ccl::Mesh* m_cyclesVolume;


### PR DESCRIPTION
Added a function to update the openvdb grid of the "HdCyclesVolumeLoader", which is cleared by the cycles "device_load_image" function. This grid is needed for constructing a mesh and was causing a crash when volumes are updated. 

Fixes PT-835

Testing procedure:

* Download the test file
* Render in viewport with cycles
* Disable transform and render a second time, HdCycles shouldn't crash anymore.

[test file](https://github.com/tangent-opensource/hdcycles/files/6207197/volume_update.zip)
