### PR TITLE
Sampling-related fixes

### DIFF
--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -410,6 +410,7 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key,
         sessionParams = &m_cyclesSession->params;
 
     bool session_updated = false;
+    bool samples_updated = false;
 
     // This is now handled by HdCycles depending on tiled or not tiled rendering...
     /*if (key == usdCyclesTokens->cyclesBackground) {
@@ -441,9 +442,29 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key,
     }
 
     if (key == usdCyclesTokens->cyclesSamples) {
+        // If branched-path mode is set, make sure to set samples to use the
+        // aa_samples instead from the integrator.
+        int samples = sessionParams->samples;
+        ccl::Integrator::Method method = ccl::Integrator::PATH;
+
+        if (m_cyclesScene) {
+            method = m_cyclesScene->integrator->method;
+
+            if (method == ccl::Integrator::BRANCHED_PATH) {
+                samples = m_cyclesScene->integrator->aa_samples;
+            }
+        }
+
         sessionParams->samples
-            = _HdCyclesGetVtValue<int>(value, sessionParams->samples,
-                                       &session_updated);
+            = _HdCyclesGetVtValue<int>(value, samples,
+                                       &samples_updated);
+        if (samples_updated) {
+            session_updated = true;
+
+            if (m_cyclesScene && method == ccl::Integrator::BRANCHED_PATH) {
+                sessionParams->samples = m_cyclesScene->integrator->aa_samples;
+            }
+        }
     }
 
     // Tiles
@@ -776,6 +797,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key,
 
     ccl::Integrator* integrator = m_cyclesScene->integrator;
     bool integrator_updated     = false;
+    bool method_updated         = false;
 
     if (key == usdCyclesTokens->cyclesIntegratorSeed) {
         integrator->seed = _HdCyclesGetVtValue<int>(value, integrator->seed,
@@ -797,23 +819,45 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key,
     if (key == usdCyclesTokens->cyclesIntegratorMethod) {
         TfToken integratorMethod
             = _HdCyclesGetVtValue<TfToken>(value, usdCyclesTokens->path,
-                                           &integrator_updated);
+                                           &method_updated);
         if (integratorMethod == usdCyclesTokens->path) {
             integrator->method = ccl::Integrator::PATH;
         } else {
             integrator->method = ccl::Integrator::BRANCHED_PATH;
         }
+
+        if (method_updated) {
+            integrator_updated = true;
+            if (integrator->method == ccl::Integrator::BRANCHED_PATH) {
+                m_cyclesSession->params.samples = integrator->aa_samples;
+            }
+        }
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorSampling_method) {
+        TfToken defaultPattern = usdCyclesTokens->sobol;
+        if (integrator->sampling_pattern == ccl::SAMPLING_PATTERN_CMJ) {
+            defaultPattern = usdCyclesTokens->cmj;
+        }
+        else if(integrator->sampling_pattern == ccl::SAMPLING_PATTERN_PMJ) {
+            defaultPattern = usdCyclesTokens->pmj;
+        }
+
         TfToken samplingMethod
-            = _HdCyclesGetVtValue<TfToken>(value, usdCyclesTokens->sobol,
+            = _HdCyclesGetVtValue<TfToken>(value, defaultPattern,
                                            &integrator_updated);
         if (samplingMethod == usdCyclesTokens->sobol) {
             integrator->sampling_pattern = ccl::SAMPLING_PATTERN_SOBOL;
         } else if (samplingMethod == usdCyclesTokens->cmj) {
             integrator->sampling_pattern = ccl::SAMPLING_PATTERN_CMJ;
         } else {
+            integrator->sampling_pattern = ccl::SAMPLING_PATTERN_PMJ;
+        }
+
+        // Adaptive sampling must use PMJ
+        if (m_cyclesSession->params.adaptive_sampling && 
+            integrator->sampling_pattern != ccl::SAMPLING_PATTERN_PMJ) {
+            integrator_updated = true;
             integrator->sampling_pattern = ccl::SAMPLING_PATTERN_PMJ;
         }
     }
@@ -885,6 +929,9 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key,
             if (m_useSquareSamples) {
                 integrator->aa_samples = integrator->aa_samples
                                          * integrator->aa_samples;
+            }
+            if (integrator->method == ccl::Integrator::BRANCHED_PATH) {
+                m_cyclesSession->params.samples = integrator->aa_samples;
             }
             integrator_updated = true;
         }
@@ -2105,6 +2152,7 @@ HdCyclesRenderParam::SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
     m_aovs = a_aovs;
     m_bufferParams.passes.clear();
     bool has_combined = false;
+    bool has_sample_count = false;
     ccl::Film *film = m_cyclesScene->film;
 
     ccl::CryptomatteType cryptomatte_passes = ccl::CRYPT_NONE;
@@ -2125,6 +2173,9 @@ HdCyclesRenderParam::SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
             if (sourceName == cyclesAov.token) {
                 if (cyclesAov.type == ccl::PASS_COMBINED) {
                     has_combined = true;
+                }
+                else if(cyclesAov.type == ccl::PASS_SAMPLE_COUNT) {
+                    has_sample_count = true;
                 }
                 ccl::Pass::add(cyclesAov.type, m_bufferParams.passes, cyclesAov.name.c_str(), cyclesAov.filter);
                 continue;
@@ -2192,7 +2243,9 @@ HdCyclesRenderParam::SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
     if (m_sessionParams.adaptive_sampling)
     {
         ccl::Pass::add(ccl::PASS_ADAPTIVE_AUX_BUFFER, m_bufferParams.passes);
-        ccl::Pass::add(ccl::PASS_SAMPLE_COUNT, m_bufferParams.passes);
+        if (!has_sample_count) {
+            ccl::Pass::add(ccl::PASS_SAMPLE_COUNT, m_bufferParams.passes);
+        }
     }
 
     if (!has_combined) {

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -410,6 +410,7 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key,
         sessionParams = &m_cyclesSession->params;
 
     bool session_updated = false;
+    bool samples_updated = false;
 
     // This is now handled by HdCycles depending on tiled or not tiled rendering...
     /*if (key == usdCyclesTokens->cyclesBackground) {

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -410,7 +410,6 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key,
         sessionParams = &m_cyclesSession->params;
 
     bool session_updated = false;
-    bool samples_updated = false;
 
     // This is now handled by HdCycles depending on tiled or not tiled rendering...
     /*if (key == usdCyclesTokens->cyclesBackground) {


### PR DESCRIPTION
- Blender backend sets AA samples back onto the session's global samples when in branched-path mode, overriding what's there
- Make sure to set the sampling pattern to PMJ when in adaptive sampling mode
- Make sure to only create one sample count pass when in adaptive sampling mode