### PR TITLE
Default color AOV fix

### DIFF
--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -109,11 +109,20 @@ std::array<HdCyclesAov, 3> CryptomatteAovs = {{
     { "CryptoAsset", ccl::PASS_CRYPTOMATTE, HdCyclesAovTokens->CryptoAsset, HdFormatFloat32Vec4, true },
 }};
 
+// Workaround for Houdini's default color buffer naming convention (not using HdAovTokens->color)
+const TfToken defaultHoudiniColor = TfToken("C.*");
+
 TfToken GetSourceName(const HdRenderPassAovBinding &aov) {
     const auto &it = aov.aovSettings.find(UsdRenderTokens->sourceName);
     if (it != aov.aovSettings.end()) {
         if (it->second.IsHolding<std::string>()) {
-            return TfToken(it->second.UncheckedGet<std::string>());
+            TfToken token = TfToken(it->second.UncheckedGet<std::string>());
+            if (token == defaultHoudiniColor) {
+                return HdAovTokens->color;
+            }
+            else {
+                return token;
+            }
         }
     }
 


### PR DESCRIPTION
When there is no AOV specified, Houdini uses the token "C.*" as default which Cycles doesn't understand fully as it doesn't do LPEs yet, so this is a workaround to use HdAovTokens->color instead which is just the string "color".