### PR TITLE
Remove lock from tile rendering callback

### DIFF
--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1456,8 +1456,6 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
     if (!m_useTiledRendering)
         return;
 
-    ccl::thread_scoped_lock session_lock(m_cyclesScene->mutex);
-
     const int w = rtile.w;
     const int h = rtile.h;
 


### PR DESCRIPTION
This lock was causing a deadlock on Linux and preventing tiled rendering from working, found this while debugging the aa_samples issue.