### PR TITLE
Use tbb to set number of threads

### DIFF
--- a/plugin/hdCycles/config.cpp
+++ b/plugin/hdCycles/config.cpp
@@ -120,7 +120,6 @@ HdCyclesConfig::HdCyclesConfig()
 
     max_samples = HdCyclesEnvValue<int>("HD_CYCLES_MAX_SAMPLES", 512);
 
-    num_threads             = HdCyclesEnvValue<int>("HD_CYCLES_NUM_THREADS", 0);
     pixel_size              = HdCyclesEnvValue<int>("HD_CYCLES_PIXEL_SIZE", 1);
     tile_size_x             = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_X", 64);
     tile_size_y             = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_Y", 64);

--- a/plugin/hdCycles/config.h
+++ b/plugin/hdCycles/config.h
@@ -246,12 +246,6 @@ public:
     HdCyclesEnvValue<int> max_samples;
 
     /**
-     * @brief Number of threads to use for cycles render
-     *
-     */
-    HdCyclesEnvValue<int> num_threads;
-
-    /**
      * @brief Size of pixel
      *
      */

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -268,7 +268,6 @@ void _UpdateHuskSessionParams(ccl::SessionParams& session_params, const HdRender
             if(it != args.end() && (++it) != args.end()) {
                 try {
                     auto num_requested_threads = std::stoi(*it);
-                    std::cout << num_requested_threads << std::endl;
                     if(num_requested_threads >= 0) {
                         session_params.threads = num_requested_threads;
                     } else {


### PR DESCRIPTION
Adding functionality to respect `-j`/`--threads` from Husk. This is a temporary solution. When SideFx exposes Husk's TfTokens they can be taken from a header distributed with Houdini.