### PR TITLE
Always set default values at the start of a sync

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -409,6 +409,13 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     bool generate_new_curve = false;
     bool update_curve       = false;
 
+    // Defaults
+    m_visCamera = m_visDiffuse = m_visGlossy = m_visScatter = m_visShadow = m_visTransmission = true;
+    m_useMotionBlur = false;
+    m_cyclesObject->is_shadow_catcher = false;
+    m_cyclesObject->pass_id = 0;
+    m_cyclesObject->use_holdout = false;
+
     if (*dirtyBits & HdChangeTracker::DirtyPoints) {
         HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
         if (HdCyclesIsPrimvarExists(HdTokens->points, pdpi)) {

--- a/plugin/hdCycles/light.cpp
+++ b/plugin/hdCycles/light.cpp
@@ -201,6 +201,16 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
 
     bool light_updated = false;
 
+    // Defaults
+    m_cyclesLight->use_diffuse = true;
+    m_cyclesLight->use_glossy = true;
+    m_cyclesLight->use_transmission = true;
+    m_cyclesLight->use_scatter = true;
+    m_cyclesLight->use_mis = true;
+    m_cyclesLight->is_portal = false;
+    m_cyclesLight->samples = 1;
+    m_cyclesLight->max_bounces = 1024;
+
     if (*dirtyBits & HdLight::DirtyParams) {
         light_updated              = true;
         ccl::ShaderGraph* oldGraph = m_cyclesLight->shader->graph;

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1193,6 +1193,16 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
 
     };
 
+    // Set defaults, so that in a "do nothing" scenario it'll revert to defaults, or if you view
+    // a different node context without any settings set.
+    m_visCamera = m_visDiffuse = m_visGlossy =  m_visScatter = m_visShadow = m_visTransmission = true;
+    m_useMotionBlur = false;
+    m_useDeformMotionBlur = false;
+    m_motionSteps = 3;
+    m_cyclesObject->is_shadow_catcher = false;
+    m_cyclesObject->pass_id = 0;
+    m_cyclesObject->use_holdout = false;
+
     for (auto& primvarDescsEntry : primvarDescsPerInterpolation) {
         for (auto& pv : primvarDescsEntry.second) {
             // Mesh Specific

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -242,6 +242,10 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
 
     ccl::vector<int> old_voxel_slots = get_voxel_image_slots(m_cyclesVolume);
 
+    // Defaults
+    m_useMotionBlur = false;
+    m_cyclesObject->velocity_scale = 1.0f;
+
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
         m_cyclesVolume->clear();
         _PopulateVolume(id, sceneDelegate, scene);


### PR DESCRIPTION
Always set default values at the start of a sync, so that when a "do nothing" is set in Solaris, or a different node is picked, it'll start back with sane defaults. This addresses curves, lights, meshes and volumes.

TODO: All global values in renderParam need the defaults set on any scene refresh also, but for now we can just be explicit with our RenderSettings node (seems like no other delegate works correctly here as well, including PRMan).

And as an extra note, we may need to be vigilant on any new schema that gets added here. We can also use the cycles node API to set built-in defaults if we prefer also, but lets do that once we upgrade to the latest cycles API just in case they have a new/different way now.