### PR TITLE
Distribution enum value out of range and fallback to default GGX

### DIFF
--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -383,13 +383,14 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
 
             case ccl::SocketType::ENUM: {
                 if (params.second.IsHolding<int>()) {
+                    const ccl::NodeEnum& node_enums = *socket.enum_values;
                     auto index = params.second.Get<int>();
-                    if (index < socket.size()) {
-                        const std::string& str = socket.enum_values->operator[](index).string();
-                        cyclesNode->set(socket, str.c_str());
+                    if(node_enums.exists(index)) {
+                        const std::string& value = node_enums[index].string();
+                        cyclesNode->set(socket, value.c_str());
                     } else {
-                        TF_CODING_ERROR("Invalid enumerator for: %s", usd_node.identifier.GetString().c_str());
-                        return nullptr;
+                        // fallback to blender default's option
+                        cyclesNode->set(socket, "GGX");
                     }
                 } else if (params.second.IsHolding<std::string>()) {
                     cyclesNode->set(socket, params.second.Get<std::string>().c_str());

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -390,7 +390,7 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
                         cyclesNode->set(socket, value);
                     } else {
                         // fallback to Blender's defaults
-                        if(cycles_node_name == "cycles_principled_bsdf") {
+                        if(cycles_node_name == "principled_bsdf") {
                             cyclesNode->set(socket, "GGX");
                         } else {
                             TF_CODING_ERROR("Invalid enum without fallback value");

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -386,11 +386,15 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
                     const ccl::NodeEnum& node_enums = *socket.enum_values;
                     auto index = params.second.Get<int>();
                     if(node_enums.exists(index)) {
-                        const std::string& value = node_enums[index].string();
-                        cyclesNode->set(socket, value.c_str());
+                        const char* value = node_enums[index].string().c_str();
+                        cyclesNode->set(socket, value);
                     } else {
-                        // fallback to blender default's option
-                        cyclesNode->set(socket, "GGX");
+                        // fallback to Blender's defaults
+                        if(cycles_node_name == "cycles_principled_bsdf") {
+                            cyclesNode->set(socket, "GGX");
+                        } else {
+                            TF_CODING_ERROR("Invalid enum without fallback value");
+                        }
                     }
                 } else if (params.second.IsHolding<std::string>()) {
                     cyclesNode->set(socket, params.second.Get<std::string>().c_str());


### PR DESCRIPTION
Certain scenes contain materials that the index is out of range. I am not sure if the check `index < socket.size()` is the right way to go to prevent scenes from crashing.