### PR TITLE
fixing null ptr camera

### DIFF
--- a/plugin/hdCycles/CMakeLists.txt
+++ b/plugin/hdCycles/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(hdCycles SHARED
         objectSource.h
         attributeSource.cpp
         attributeSource.h
+        renderPassState.cpp
+        renderPassState.h
         )
 
 target_include_directories(hdCycles

--- a/plugin/hdCycles/objectSource.cpp
+++ b/plugin/hdCycles/objectSource.cpp
@@ -65,17 +65,21 @@ HdCyclesObjectSource::GetName() const
     return m_id.GetToken();
 }
 
-void
+size_t
 HdCyclesObjectSource::ResolvePendingSources()
 {
+    size_t num_resolved_sources = 0;
+
     // resolve pending sources
     for (auto& source : m_pending_sources) {
         if (!source.second->IsValid()) {
             continue;
         }
         source.second->Resolve();
+        ++num_resolved_sources;
     }
 
     // cleanup sources right after the resolve
     m_pending_sources.clear();
+    return num_resolved_sources;
 }

--- a/plugin/hdCycles/objectSource.h
+++ b/plugin/hdCycles/objectSource.h
@@ -49,7 +49,7 @@ public:
 
     // TODO: Resolve binds object to the scene
     bool Resolve() override;
-    void ResolvePendingSources();
+    size_t ResolvePendingSources();
 
     const TfToken& GetName() const override;
     void GetBufferSpecs(HdBufferSpecVector* specs) const override {}

--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -33,6 +33,7 @@
 #include "renderBuffer.h"
 #include "renderParam.h"
 #include "renderPass.h"
+#include "renderPassState.h"
 #include "utils.h"
 
 #include <render/background.h>
@@ -408,6 +409,12 @@ HdCyclesRenderDelegate::Resume()
 {
     m_renderParam->ResumeRender();
     return true;
+}
+
+HdRenderPassStateSharedPtr
+HdCyclesRenderDelegate::CreateRenderPassState() const
+{
+    return std::make_shared<HdCyclesRenderPassState>(this);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/renderDelegate.h
+++ b/plugin/hdCycles/renderDelegate.h
@@ -179,9 +179,11 @@ public:
 
     virtual HdResourceRegistrySharedPtr GetResourceRegistry() const override;
 
-    // Prims
-    virtual HdRenderPassSharedPtr CreateRenderPass(HdRenderIndex* index, HdRprimCollection const& collection) override;
+    // Render Pass and State
+    HdRenderPassSharedPtr CreateRenderPass(HdRenderIndex* index, HdRprimCollection const& collection) override;
+    HdRenderPassStateSharedPtr CreateRenderPassState() const override;
 
+    // Prims
     HdInstancer* CreateInstancer(HdSceneDelegate* delegate, SdfPath const& id, SdfPath const& instancerId) override;
     void DestroyInstancer(HdInstancer* instancer) override;
 

--- a/plugin/hdCycles/renderPassState.cpp
+++ b/plugin/hdCycles/renderPassState.cpp
@@ -1,0 +1,44 @@
+//  Copyright 2021 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "renderPassState.h"
+#include "camera.h"
+#include "resourceRegistry.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+HdCyclesRenderPassState::HdCyclesRenderPassState(const HdCyclesRenderDelegate* renderDelegate)
+    : m_renderDelegate { renderDelegate }
+{
+}
+
+void
+HdCyclesRenderPassState::Prepare(const HdResourceRegistrySharedPtr& resourceRegistry)
+{
+    HdCyclesResourceRegistry* registry = dynamic_cast<HdCyclesResourceRegistry*>(resourceRegistry.get());
+    if(!registry) {
+        return;
+    }
+
+    // TODO: Resource registry is a shared pointer that is const, but the pointer held is not const!
+    //       We can continue committing camera changes from here. That means no need to cast away const correctness
+    //       for the camera. The camera render parameters are set through HdxRenderSetupTask::PrepareCamera.
+    //       All code related to camera update should be moved here, and committed to resource registry as pending
+    //       source.
+}

--- a/plugin/hdCycles/renderPassState.h
+++ b/plugin/hdCycles/renderPassState.h
@@ -1,0 +1,43 @@
+//  Copyright 2021 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef HDCYCLES_RENDERPASSSTATE_H
+#define HDCYCLES_RENDERPASSSTATE_H
+
+#include <pxr/imaging/hd/renderPassState.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdCyclesRenderDelegate;
+
+class HdCyclesRenderPassState : public HdRenderPassState {
+public:
+    explicit HdCyclesRenderPassState(const HdCyclesRenderDelegate* renderDelegate);
+
+    void Prepare(const HdResourceRegistrySharedPtr& resourceRegistry) override;
+
+private:
+    const HdCyclesRenderDelegate* m_renderDelegate;
+};
+
+using HdCyclesRenderPassStateSharedPtr = std::shared_ptr<HdCyclesRenderPassState>;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  //HDCYCLES_RENDERPASSSTATE_H


### PR DESCRIPTION
In some situations switching between Houdini viewport and the camera causes Houdini to crash. In the process of switching `HdRenderPassState` can hold null camera pointer. That happens because after removing `SPrim` new `HdCamera` has not been created yet.

