### PR TITLE
Add new Diagnostic Delegate to re-direct errors to stdout

### DIFF
--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -61,6 +61,10 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 TF_DEFINE_PUBLIC_TOKENS(HdCyclesIntegratorTokens, HDCYCLES_INTEGRATOR_TOKENS);
 TF_DEFINE_PUBLIC_TOKENS(HdCyclesAovTokens, HDCYCLES_AOV_TOKENS);
 
+PXR_NAMESPACE_CLOSE_SCOPE
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
 // clang-format off
 const TfTokenVector HdCyclesRenderDelegate::SUPPORTED_RPRIM_TYPES = {
     HdPrimTypeTokens->mesh,
@@ -417,4 +421,50 @@ HdCyclesRenderDelegate::CreateRenderPassState() const
     return std::make_shared<HdCyclesRenderPassState>(this);
 }
 
-PXR_NAMESPACE_CLOSE_SCOPE
+HdCyclesDiagnosticDelegate::HdCyclesDiagnosticDelegate(std::ostream& os)
+    : _os { os }
+{
+}
+
+void
+HdCyclesDiagnosticDelegate::IssueError(const TfError& err)
+{
+    IssueDiagnosticBase(err);
+}
+
+HdCyclesDiagnosticDelegate::~HdCyclesDiagnosticDelegate() {}
+
+void
+HdCyclesDiagnosticDelegate::IssueFatalError(const TfCallContext& context, const std::string& msg)
+{
+    std::string message = TfStringPrintf("[FATAL ERROR] %s -- in %s at line %zu of %s", msg.c_str(),
+                                         context.GetFunction(), context.GetLine(), context.GetFile());
+    IssueMessage(message);
+}
+
+void
+HdCyclesDiagnosticDelegate::IssueDiagnosticBase(const TfDiagnosticBase& d)
+{
+    std::string msg = TfStringPrintf("%s -- %s in %s at line %zu of %s", d.GetCommentary().c_str(),
+                                     TfDiagnosticMgr::GetCodeName(d.GetDiagnosticCode()).c_str(),
+                                     d.GetContext().GetFunction(), d.GetContext().GetLine(), d.GetContext().GetFile());
+    IssueMessage(msg);
+}
+
+HdCyclesRenderDelegate::HdCyclesDiagnosticDelegateHolder::HdCyclesDiagnosticDelegateHolder()
+{
+    // add extra output file etc, if required
+    std::string error_output = TfGetenv("HD_CYCLES_DIAGNOSTIC_OUTPUT", "stdout");
+    if (error_output == "stdout") {
+        _delegate = std::make_unique<HdCyclesDiagnosticDelegate>(std::cout);
+        TfDiagnosticMgr::GetInstance().AddDelegate(_delegate.get());
+        return;
+    }
+}
+
+HdCyclesRenderDelegate::HdCyclesDiagnosticDelegateHolder::~HdCyclesDiagnosticDelegateHolder()
+{
+    if (_delegate) {
+        TfDiagnosticMgr::GetInstance().RemoveDelegate(_delegate.get());
+    }
+}

--- a/plugin/hdCycles/renderDelegate.h
+++ b/plugin/hdCycles/renderDelegate.h
@@ -23,6 +23,7 @@
 #include "api.h"
 #include "resourceRegistry.h"
 
+#include <pxr/base/tf/diagnosticMgr.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/pxr.h>
@@ -140,6 +141,26 @@ TF_DECLARE_PUBLIC_TOKENS(HdCyclesAovTokens,
 
 // clang-format on
 
+///
+/// Issues errors messages to specified ostream
+///
+class HdCyclesDiagnosticDelegate : public TfDiagnosticMgr::Delegate {
+public:
+    explicit HdCyclesDiagnosticDelegate(std::ostream& os);
+    ~HdCyclesDiagnosticDelegate() override;
+
+    void IssueError(const TfError& err) override;
+    void IssueFatalError(const TfCallContext& context, const std::string& msg) override;
+    void IssueStatus(const TfStatus& status) override {}
+    void IssueWarning(const TfWarning& warning) override {}
+
+private:
+    void IssueDiagnosticBase(const TfDiagnosticBase& d);
+    void IssueMessage(const std::string& message) { _os << message << '\n'; }
+
+    std::ostream& _os;
+};
+
 /**
  * @brief Represents the core interactions between Cycles and Hydra.
  * Responsible for creating and deleting scene primitives, and
@@ -207,19 +228,17 @@ public:
 
     virtual VtDictionary GetRenderStats() const override;
 
-protected:
+private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;
     static const TfTokenVector SUPPORTED_BPRIM_TYPES;
 
-private:
     // This class does not support copying.
     HdCyclesRenderDelegate(const HdCyclesRenderDelegate&) = delete;
     HdCyclesRenderDelegate& operator=(const HdCyclesRenderDelegate&) = delete;
 
     void _Initialize(HdRenderSettingsMap const& settingsMap);
 
-protected:  // data
     HdCyclesRenderPass* m_renderPass;
     HdRenderSettingDescriptorList m_settingDescriptors;
 
@@ -229,6 +248,20 @@ protected:  // data
 
     std::unique_ptr<HdCyclesRenderParam> m_renderParam;
     bool m_hasStarted;
+
+    ///
+    /// Auto add/remove cycles diagnostic delegate
+    ///
+    class HdCyclesDiagnosticDelegateHolder {
+    public:
+        HdCyclesDiagnosticDelegateHolder();
+        ~HdCyclesDiagnosticDelegateHolder();
+
+    private:
+        std::unique_ptr<HdCyclesDiagnosticDelegate> _delegate;
+    };
+
+    HdCyclesDiagnosticDelegateHolder _diagnostic_holder;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
New diagnostic delegate allows us to output errors and fatal errors to `stdout`. Easily if we wish we could modify the implementation and save the diagnostic information to a file. 