### PR TITLE
Changed the tile_size render setting schema type to integer 

### DIFF
--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -463,14 +463,18 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key, const VtVal
     // Tiles
 
     if (key == usdCyclesTokens->cyclesTile_size) {
-        sessionParams->tile_size = vec2f_to_int2(
-            _HdCyclesGetVtValue<GfVec2f>(value, int2_to_vec2f(sessionParams->tile_size), &session_updated));
-
-        // Adding this check for safety since the original implementation was using GfVec2i which
-        // might have been valid at some point but does not match the current schema.
         if (value.IsHolding<GfVec2i>()) {
+            sessionParams->tile_size = vec2i_to_int2(
+                _HdCyclesGetVtValue<GfVec2i>(value, int2_to_vec2i(sessionParams->tile_size), &session_updated));
+        } else if (value.IsHolding<GfVec2f>()) {
+            // Adding this check for safety since the original implementation was using GfVec2i which
+            // might have been valid at some point but does not match the current schema.
+            sessionParams->tile_size = vec2f_to_int2(
+                _HdCyclesGetVtValue<GfVec2f>(value, int2_to_vec2f(sessionParams->tile_size), &session_updated));
             TF_WARN(
-                "Tile size was specified as integer, but the schema defines it as float. Please check you used the right schema version and report this.");
+                "Tile size was specified as float, but the schema uses int. The value will be converted but you should update the schema version.");
+        } else {
+            TF_WARN("Tile size has unsupported type %s, expected GfVec2f", value.GetTypeName().c_str());
         }
     }
 

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -463,8 +463,15 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key, const VtVal
     // Tiles
 
     if (key == usdCyclesTokens->cyclesTile_size) {
-        sessionParams->tile_size = vec2i_to_int2(
-            _HdCyclesGetVtValue<GfVec2i>(value, int2_to_vec2i(sessionParams->tile_size), &session_updated));
+        sessionParams->tile_size = vec2f_to_int2(
+            _HdCyclesGetVtValue<GfVec2f>(value, int2_to_vec2f(sessionParams->tile_size), &session_updated));
+
+        // Adding this check for safety since the original implementation was using GfVec2i which
+        // might have been valid at some point but does not match the current schema.
+        if (value.IsHolding<GfVec2i>()) {
+            TF_WARN(
+                "Tile size was specified as integer, but the schema defines it as float. Please check you used the right schema version and report this.");
+        }
     }
 
     TfToken tileOrder;

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -236,9 +236,9 @@ HdCyclesSetTransform(ccl::Object* object, HdSceneDelegate* delegate, const SdfPa
         }
 
         // Rounding to odd number of samples to have one in the center
-        const size_t sampleOffset     = (sampleCount % 2) ? 0 : 1;
-        const size_t numMotionSteps   = sampleCount + static_cast<size_t>(sampleOffset);
-        const float motionStepSize = (xf.times.back() - xf.times.front()) / static_cast<float>((numMotionSteps - 1));
+        const size_t sampleOffset   = (sampleCount % 2) ? 0 : 1;
+        const size_t numMotionSteps = sampleCount + static_cast<size_t>(sampleOffset);
+        const float motionStepSize  = (xf.times.back() - xf.times.front()) / static_cast<float>((numMotionSteps - 1));
         object->motion.resize(numMotionSteps, ccl::transform_empty());
 
         // For each step, we use the available data from the neighbors
@@ -392,10 +392,22 @@ int2_to_vec2i(const ccl::int2& a_int)
     return GfVec2i(a_int.x, a_int.y);
 }
 
+GfVec2f
+int2_to_vec2f(const ccl::int2& a_int)
+{
+    return GfVec2f(static_cast<float>(a_int.x), static_cast<float>(a_int.y));
+}
+
 ccl::float2
 vec2f_to_float2(const GfVec2f& a_vec)
 {
     return ccl::make_float2(a_vec[0], a_vec[1]);
+}
+
+ccl::int2
+vec2f_to_int2(const GfVec2f& a_vec)
+{
+    return ccl::make_int2(static_cast<int>(a_vec[0]), static_cast<int>(a_vec[1]));
 }
 
 ccl::float2

--- a/plugin/hdCycles/utils.h
+++ b/plugin/hdCycles/utils.h
@@ -211,12 +211,22 @@ vec2i_to_int2(const GfVec2i& a_vec);
 
 /**
  * @brief Convert int2 to GfVec2i representation
- * 
- * @param a_int 
+ *
+ * @param a_int
  * @return GfVec2i 
  */
 GfVec2i
 int2_to_vec2i(const ccl::int2& a_int);
+
+/**
+ * @brief Convert int2 to GfVec2f representation
+ * 
+ * @param a_int 
+ * @return GfVec2f
+ */
+GfVec2f
+int2_to_vec2f(const ccl::int2& a_int);
+
 
 /**
  * @brief Convert GfVec2f to Cycles float2 representation
@@ -226,6 +236,17 @@ int2_to_vec2i(const ccl::int2& a_int);
  */
 ccl::float2
 vec2f_to_float2(const GfVec2f& a_vec);
+
+
+/**
+ * @brief Convert GfVec2f to Cycles int2 representation
+ *
+ * @param a_vec
+ * @return Cycles int2
+ */
+ccl::int2
+vec2f_to_int2(const GfVec2f& a_vec);
+
 
 /**
  * @brief Convert GfVec2i to Cycles float2 representation

--- a/plugin/usdCycles/schema.usda
+++ b/plugin/usdCycles/schema.usda
@@ -128,7 +128,7 @@ class "CyclesRendererSettingsAPI" (
         doc = "Number of threads to render with"
     )
 
-    uniform float2 cycles:tile_size = (64, 64) (
+    uniform int2 cycles:tile_size = (64, 64) (
         customData = {
             string apiName = "tile_size"
         }


### PR DESCRIPTION
Tile size was read as GfVec2i while the schema defines it as GfVec2f. Issuing a warning for now. 
Maybe this should be automatically converted, but strict compliance with the schema is also good.

Internal ticket #6655